### PR TITLE
Deflectometry old merge fixes

### DIFF
--- a/contrib/app/sofast/run_full_calibration_manual.py
+++ b/contrib/app/sofast/run_full_calibration_manual.py
@@ -42,8 +42,7 @@ def run_screen_shape_cal(
     """
     # Define input files
     resolution_xy = [100, 100]  # sample density of screen
-    file_screen_cal_point_pairs = join(
-        dir_input, 'screen_calibration_point_pairs.csv')
+    file_screen_cal_point_pairs = join(dir_input, 'screen_calibration_point_pairs.csv')
     file_camera_distortion = join(dir_input, 'camera_screen_shape.h5')
     file_image_projection = join(dir_input, 'image_projection.h5')
     files_screen_shape_measurement = glob(
@@ -57,8 +56,7 @@ def run_screen_shape_cal(
         file_screen_cal_point_pairs, delimiter=',', skiprows=1
     ).astype(int)
     camera = Camera.load_from_hdf(file_camera_distortion)
-    image_projection_data = ImageProjection.load_from_hdf(
-        file_image_projection)
+    image_projection_data = ImageProjection.load_from_hdf(file_image_projection)
 
     # Store input data in data class
     data_input = DataInput(
@@ -124,20 +122,17 @@ if __name__ == '__main__':
     )
 
     # Run screen shape calibration
-    cal_screen_shape = run_screen_shape_cal(
-        pts_data, base_dir_sofast, VERBOSITY)
+    cal_screen_shape = run_screen_shape_cal(pts_data, base_dir_sofast, VERBOSITY)
 
     # Run camera position calibration
-    cal_camera_pose = run_camera_position_cal(
-        pts_data, base_dir_sofast, VERBOSITY)
+    cal_camera_pose = run_camera_position_cal(pts_data, base_dir_sofast, VERBOSITY)
 
     # Save calibration figures
     for fig in cal_screen_shape.figures + cal_camera_pose.figures:
         fig.savefig(join(save_dir, fig.get_label() + '.png'))
 
     # Save raw data
-    cal_screen_shape.save_data_as_hdf(
-        join(save_dir, 'screen_distortion_data.h5'))
+    cal_screen_shape.save_data_as_hdf(join(save_dir, 'screen_distortion_data.h5'))
     cal_camera_pose.save_data_as_csv(join(save_dir, 'camera_rvec_tvec.csv'))
 
     # Save physical setup file
@@ -145,5 +140,4 @@ if __name__ == '__main__':
     NAME = 'Example physical setup file'
     screen_distortion_data = cal_screen_shape.get_data()
     rvec, tvec = cal_camera_pose.get_data()
-    save_physical_setup_file(screen_distortion_data,
-                             NAME, rvec, tvec, file_save)
+    save_physical_setup_file(screen_distortion_data, NAME, rvec, tvec, file_save)

--- a/contrib/app/sofast/run_full_calibration_manual.py
+++ b/contrib/app/sofast/run_full_calibration_manual.py
@@ -42,7 +42,8 @@ def run_screen_shape_cal(
     """
     # Define input files
     resolution_xy = [100, 100]  # sample density of screen
-    file_screen_cal_point_pairs = join(dir_input, 'screen_calibration_point_pairs.csv')
+    file_screen_cal_point_pairs = join(
+        dir_input, 'screen_calibration_point_pairs.csv')
     file_camera_distortion = join(dir_input, 'camera_screen_shape.h5')
     file_image_projection = join(dir_input, 'image_projection.h5')
     files_screen_shape_measurement = glob(
@@ -56,7 +57,8 @@ def run_screen_shape_cal(
         file_screen_cal_point_pairs, delimiter=',', skiprows=1
     ).astype(int)
     camera = Camera.load_from_hdf(file_camera_distortion)
-    image_projection_data = ImageProjection.load_from_hdf(file_image_projection)
+    image_projection_data = ImageProjection.load_from_hdf(
+        file_image_projection)
 
     # Store input data in data class
     data_input = DataInput(
@@ -93,7 +95,8 @@ def run_camera_position_cal(
 
     # Perform camera position calibraiton
     cal = CalibrationCameraPosition(camera, pts_xyz_marker, corner_ids, image)
-    cal.run_calibration(verbose)
+    cal.verbose = verbose
+    cal.run_calibration()
 
     return cal
 
@@ -121,17 +124,20 @@ if __name__ == '__main__':
     )
 
     # Run screen shape calibration
-    cal_screen_shape = run_screen_shape_cal(pts_data, base_dir_sofast, VERBOSITY)
+    cal_screen_shape = run_screen_shape_cal(
+        pts_data, base_dir_sofast, VERBOSITY)
 
     # Run camera position calibration
-    cal_camera_pose = run_camera_position_cal(pts_data, base_dir_sofast, VERBOSITY)
+    cal_camera_pose = run_camera_position_cal(
+        pts_data, base_dir_sofast, VERBOSITY)
 
     # Save calibration figures
     for fig in cal_screen_shape.figures + cal_camera_pose.figures:
         fig.savefig(join(save_dir, fig.get_label() + '.png'))
 
     # Save raw data
-    cal_screen_shape.save_data_as_hdf(join(save_dir, 'screen_distortion_data.h5'))
+    cal_screen_shape.save_data_as_hdf(
+        join(save_dir, 'screen_distortion_data.h5'))
     cal_camera_pose.save_data_as_csv(join(save_dir, 'camera_rvec_tvec.csv'))
 
     # Save physical setup file
@@ -139,4 +145,5 @@ if __name__ == '__main__':
     NAME = 'Example physical setup file'
     screen_distortion_data = cal_screen_shape.get_data()
     rvec, tvec = cal_camera_pose.get_data()
-    save_physical_setup_file(screen_distortion_data, NAME, rvec, tvec, file_save)
+    save_physical_setup_file(screen_distortion_data,
+                             NAME, rvec, tvec, file_save)

--- a/example/fixed_pattern_deflectometry/calculate_dot_locations_from_display_object.py
+++ b/example/fixed_pattern_deflectometry/calculate_dot_locations_from_display_object.py
@@ -20,7 +20,7 @@ from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientati
 def example_calculate_dot_locs_from_display():
     """Creates a FixedPatternDotLocations object from a previously created Display object"""
     dir_base = join(
-        dirname(opencsp.__file__),
+        opencsp_code_dir(),
         '../../sample_data/deflectometry/sandia_lab/calibration_files',
     )
 

--- a/example/fixed_pattern_deflectometry/calculate_dot_locations_from_display_object.py
+++ b/example/fixed_pattern_deflectometry/calculate_dot_locations_from_display_object.py
@@ -5,16 +5,14 @@ on a screen.
 import os
 from os.path import join, dirname, exists
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
-from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternDotLocations import (
-    FixedPatternDotLocations,
-)
-from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternScreenProjection import (
-    FixedPatternScreenProjection,
-)
+from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternDotLocations import \
+    FixedPatternDotLocations
+from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternScreenProjection import \
+    FixedPatternScreenProjection
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.common.lib.deflectometry.ImageProjection import ImageProjection
 from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 
 
 def example_calculate_dot_locs_from_display():

--- a/example/fixed_pattern_deflectometry/calculate_dot_locations_from_display_object.py
+++ b/example/fixed_pattern_deflectometry/calculate_dot_locations_from_display_object.py
@@ -5,7 +5,7 @@ on a screen.
 import os
 from os.path import join, dirname, exists
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternDotLocations import (
     FixedPatternDotLocations,
 )
@@ -51,11 +51,13 @@ def example_calculate_dot_locs_from_display():
     )
 
     # Calculate spatial orientation
-    orientation = SpatialOrientation(display.r_cam_screen, display.v_cam_screen_cam)
+    orientation = SpatialOrientation(
+        display.r_cam_screen, display.v_cam_screen_cam)
 
     # Save data sets
     fixed_pattern_dot_locs.save_to_hdf(
-        join(dir_save, f'fixed_pattern_display_w{width_dot:d}_s{spacing_dot:d}.h5')
+        join(
+            dir_save, f'fixed_pattern_display_w{width_dot:d}_s{spacing_dot:d}.h5')
     )
     orientation.save_to_hdf(join(dir_save, 'spatial_orientation.h5'))
 

--- a/example/fixed_pattern_deflectometry/calculate_dot_locations_from_display_object.py
+++ b/example/fixed_pattern_deflectometry/calculate_dot_locations_from_display_object.py
@@ -51,13 +51,11 @@ def example_calculate_dot_locs_from_display():
     )
 
     # Calculate spatial orientation
-    orientation = SpatialOrientation(
-        display.r_cam_screen, display.v_cam_screen_cam)
+    orientation = SpatialOrientation(display.r_cam_screen, display.v_cam_screen_cam)
 
     # Save data sets
     fixed_pattern_dot_locs.save_to_hdf(
-        join(
-            dir_save, f'fixed_pattern_display_w{width_dot:d}_s{spacing_dot:d}.h5')
+        join(dir_save, f'fixed_pattern_display_w{width_dot:d}_s{spacing_dot:d}.h5')
     )
     orientation.save_to_hdf(join(dir_save, 'spatial_orientation.h5'))
 

--- a/example/fixed_pattern_deflectometry/find_blobs_in_image.py
+++ b/example/fixed_pattern_deflectometry/find_blobs_in_image.py
@@ -15,7 +15,7 @@ from opencsp.common.lib.deflectometry.image_processing import detect_blobs_annot
 def example_find_blobs_in_image():
     """Finds blobs in image, annotates, and saves image"""
     file_meas = join(
-        dirname(opencsp.__file__),
+        opencsp_code_dir(),
         '../../sample_data/deflectometry/sandia_lab/fixed_pattern/measurement_screen_square_width3_space6.h5',
     )
     file_save = join(

--- a/example/fixed_pattern_deflectometry/find_blobs_in_image.py
+++ b/example/fixed_pattern_deflectometry/find_blobs_in_image.py
@@ -5,7 +5,7 @@ from os.path import join, dirname, exists
 
 import cv2 as cv
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternMeasurement import (
     FixedPatternMeasurement,
 )

--- a/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
+++ b/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
@@ -60,7 +60,8 @@ def example_perform_calibration():
     cal_dot_locs = FixedPatternSetupCalibrate(
         images, origins, camera_marker, pts_xyz_corners, ids_corners, -32, 31, -31, 32
     )
-    cal_dot_locs.verbose = 2
+    cal_dot_locs.print = True
+    cal_dot_locs.plot = True
     cal_dot_locs.run()
 
     # Perform camera position calibration

--- a/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
+++ b/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
@@ -8,13 +8,13 @@ import numpy as np
 from scipy.spatial.transform import Rotation
 
 import opencsp
-from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternSetupCalibrate import (
-    FixedPatternSetupCalibrate,
-)
+from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternSetupCalibrate import \
+    FixedPatternSetupCalibrate
+
 from opencsp.common.lib.camera.Camera import Camera
-from opencsp.common.lib.deflectometry.CalibrationCameraPosition import (
-    CalibrationCameraPosition,
-)
+from opencsp.common.lib.deflectometry.CalibrationCameraPosition import \
+    CalibrationCameraPosition
+
 from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
 from opencsp.common.lib.geometry.Vxy import Vxy
 from opencsp.common.lib.geometry.Vxyz import Vxyz
@@ -23,38 +23,22 @@ from opencsp.common.lib.geometry.Vxyz import Vxyz
 def example_perform_calibration():
     """Performs a dot-location calibration using photogrammetry"""
     # Define dot location images and origins
-    base_dir = join(dirname(opencsp.__file__), '../../sample_data/deflectometry')
+    base_dir = join(dirname(opencsp.__file__),
+                    '../../sample_data/deflectometry/calibration_dot_locations/data_measurement/')
     files = [
-        join(
-            base_dir, 'calibration_dot_locations/data_measurement/images/DSC03965.JPG'
-        ),
-        join(
-            base_dir, 'calibration_dot_locations/data_measurement/images/DSC03967.JPG'
-        ),
-        join(
-            base_dir, 'calibration_dot_locations/data_measurement/images/DSC03970.JPG'
-        ),
-        join(
-            base_dir, 'calibration_dot_locations/data_measurement/images/DSC03972.JPG'
-        ),
+        join(base_dir, 'images/DSC03965.JPG'),
+        join(base_dir, 'images/DSC03967.JPG'),
+        join(base_dir, 'images/DSC03970.JPG'),
+        join(base_dir, 'images/DSC03972.JPG'),
     ]
     origins = Vxy(([4950, 4610, 4221, 3617], [3359, 3454, 3467, 3553]))
 
     # Define other files
-    file_camera_position = join(
-        base_dir,
-        'calibration_dot_locations/data_measurement/image_deflectometry_camera.png',
-    )
-    file_camera_marker = join(
-        base_dir, 'calibration_dot_locations/data_measurement/camera_calibration.h5'
-    )
-    file_camera_system = join(
-        base_dir, 'calibration_dot_locations/data_measurement/camera_deflectometry.h5'
-    )
-    file_xyz_points = join(
-        base_dir, 'calibration_dot_locations/data_measurement/point_locations.csv'
-    )
-    dir_save = join(dirname(__file__), 'data/output/dot_location_calibraiton')
+    file_camera_position = join(base_dir, 'image_deflectometry_camera.png')
+    file_camera_marker = join(base_dir, 'camera_calibration.h5')
+    file_camera_system = join(base_dir, 'camera_deflectometry.h5')
+    file_xyz_points = join(base_dir, 'point_locations.csv')
+    dir_save = join(dirname(__file__), 'data/output/dot_location_calibration')
 
     if not exists(dir_save):
         os.makedirs(dir_save)
@@ -63,7 +47,8 @@ def example_perform_calibration():
     images = []
     for file in files:
         images.append(cv.imread(file, cv.IMREAD_GRAYSCALE))
-    image_camera_position = cv.imread(file_camera_position, cv.IMREAD_GRAYSCALE)
+    image_camera_position = cv.imread(
+        file_camera_position, cv.IMREAD_GRAYSCALE)
 
     # Load marker corner locations
     data = np.loadtxt(file_xyz_points, delimiter=',')
@@ -78,14 +63,15 @@ def example_perform_calibration():
     cal_dot_locs = FixedPatternSetupCalibrate(
         images, origins, camera_marker, pts_xyz_corners, ids_corners, -32, 31, -31, 32
     )
-    cal_dot_locs.verbose = 1
+    cal_dot_locs.verbose = 2
     cal_dot_locs.run()
 
     # Perform camera position calibration
     cal_camera = CalibrationCameraPosition(
         camera_system, pts_xyz_corners, ids_corners, image_camera_position
     )
-    cal_camera.run_calibration(2)
+    cal_camera.verbose = 2
+    cal_camera.run_calibration()
 
     # Create spatial orientation object
     rvec_screen_cam, v_cam_screen_screen = cal_camera.get_data()

--- a/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
+++ b/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
@@ -47,8 +47,7 @@ def example_perform_calibration():
     images = []
     for file in files:
         images.append(cv.imread(file, cv.IMREAD_GRAYSCALE))
-    image_camera_position = cv.imread(
-        file_camera_position, cv.IMREAD_GRAYSCALE)
+    image_camera_position = cv.imread(file_camera_position, cv.IMREAD_GRAYSCALE)
 
     # Load marker corner locations
     data = np.loadtxt(file_xyz_points, delimiter=',')

--- a/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
+++ b/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
@@ -23,7 +23,7 @@ from opencsp.common.lib.geometry.Vxyz import Vxyz
 def example_perform_calibration():
     """Performs a dot-location calibration using photogrammetry"""
     # Define dot location images and origins
-    base_dir = join(dirname(opencsp.__file__),
+    base_dir = join(opencsp_code_dir(),
                     '../../sample_data/deflectometry/calibration_dot_locations/data_measurement/')
     files = [
         join(base_dir, 'images/DSC03965.JPG'),

--- a/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
+++ b/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
@@ -7,17 +7,15 @@ import cv2 as cv
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternSetupCalibrate import \
     FixedPatternSetupCalibrate
-
 from opencsp.common.lib.camera.Camera import Camera
 from opencsp.common.lib.deflectometry.CalibrationCameraPosition import \
     CalibrationCameraPosition
-
 from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
 from opencsp.common.lib.geometry.Vxy import Vxy
 from opencsp.common.lib.geometry.Vxyz import Vxyz
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 
 
 def example_perform_calibration():

--- a/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
+++ b/example/fixed_pattern_deflectometry/physical_target_dot_calibration.py
@@ -7,7 +7,7 @@ import cv2 as cv
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternSetupCalibrate import \
     FixedPatternSetupCalibrate
 

--- a/example/fixed_pattern_deflectometry/process_fixed_pattern_data.py
+++ b/example/fixed_pattern_deflectometry/process_fixed_pattern_data.py
@@ -2,7 +2,6 @@
 """
 from os.path import join, dirname
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternDotLocations import (
     FixedPatternDotLocations,
 )
@@ -15,6 +14,7 @@ from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternProcess import (
 from opencsp.common.lib.camera.Camera import Camera
 from opencsp.common.lib.deflectometry.FacetData import FacetData
 from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 import opencsp.common.lib.render.figure_management as fm
 import opencsp.common.lib.render_control.RenderControlAxis as rca
 import opencsp.common.lib.render_control.RenderControlFigure as rcfg
@@ -33,8 +33,7 @@ def process(
     # Load data
     camera = Camera.load_from_hdf(file_camera)
     facet_data = FacetData.load_from_json(file_facet)
-    fixed_pattern_dot_locs = FixedPatternDotLocations.load_from_hdf(
-        file_dot_locs)
+    fixed_pattern_dot_locs = FixedPatternDotLocations.load_from_hdf(file_dot_locs)
     orientation = SpatialOrientation.load_from_hdf(file_ori)
     measurement = FixedPatternMeasurement.load_from_hdf(file_meas)
 
@@ -55,8 +54,7 @@ def process(
     print(f'  Y {focal_lengths_xy[1]:.3f} m')
 
     # Plot slope image
-    figure_control = rcfg.RenderControlFigure(
-        tile_array=(1, 1), tile_square=True)
+    figure_control = rcfg.RenderControlFigure(tile_array=(1, 1), tile_square=True)
     axis_control_m = rca.meters()
 
     fig_mng = fm.setup_figure(figure_control, axis_control_m, title='')
@@ -79,8 +77,7 @@ def example_process_fixed_pattern_printed_target():
     file_camera = join(dir_base, "calibration_files/camera.h5")
     file_facet = join(dir_base, "calibration_files/Facet_NSTTF.json")
     file_ori = join(dir_base, 'fixed_pattern/spatial_orientation.h5')
-    file_dot_locs = join(
-        dir_base, 'fixed_pattern/dot_locations_printed_target.h5')
+    file_dot_locs = join(dir_base, 'fixed_pattern/dot_locations_printed_target.h5')
     file_meas = join(dir_base, 'fixed_pattern/measurement_printed_target_1.h5')
     dir_output = join(dirname(__file__), 'data/output/printed_target')
 

--- a/example/fixed_pattern_deflectometry/process_fixed_pattern_data.py
+++ b/example/fixed_pattern_deflectometry/process_fixed_pattern_data.py
@@ -73,7 +73,7 @@ def example_process_fixed_pattern_printed_target():
     printed dot target.
     """
     dir_base = join(
-        dirname(opencsp.__file__), '../../sample_data/deflectometry/sandia_lab'
+        opencsp_code_dir(), '../../sample_data/deflectometry/sandia_lab'
     )
 
     file_camera = join(dir_base, "calibration_files/camera.h5")
@@ -105,7 +105,7 @@ def example_process_fixed_pattern_printed_target():
 def example_process_fixed_pattern_screen_target():
     """Loads data and calls processing function"""
     dir_base = join(
-        dirname(opencsp.__file__), '../../sample_data/deflectometry/sandia_lab'
+        opencsp_code_dir(), '../../sample_data/deflectometry/sandia_lab'
     )
 
     # Define files

--- a/example/fixed_pattern_deflectometry/process_fixed_pattern_data.py
+++ b/example/fixed_pattern_deflectometry/process_fixed_pattern_data.py
@@ -2,7 +2,7 @@
 """
 from os.path import join, dirname
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternDotLocations import (
     FixedPatternDotLocations,
 )
@@ -33,7 +33,8 @@ def process(
     # Load data
     camera = Camera.load_from_hdf(file_camera)
     facet_data = FacetData.load_from_json(file_facet)
-    fixed_pattern_dot_locs = FixedPatternDotLocations.load_from_hdf(file_dot_locs)
+    fixed_pattern_dot_locs = FixedPatternDotLocations.load_from_hdf(
+        file_dot_locs)
     orientation = SpatialOrientation.load_from_hdf(file_ori)
     measurement = FixedPatternMeasurement.load_from_hdf(file_meas)
 
@@ -54,7 +55,8 @@ def process(
     print(f'  Y {focal_lengths_xy[1]:.3f} m')
 
     # Plot slope image
-    figure_control = rcfg.RenderControlFigure(tile_array=(1, 1), tile_square=True)
+    figure_control = rcfg.RenderControlFigure(
+        tile_array=(1, 1), tile_square=True)
     axis_control_m = rca.meters()
 
     fig_mng = fm.setup_figure(figure_control, axis_control_m, title='')
@@ -77,7 +79,8 @@ def example_process_fixed_pattern_printed_target():
     file_camera = join(dir_base, "calibration_files/camera.h5")
     file_facet = join(dir_base, "calibration_files/Facet_NSTTF.json")
     file_ori = join(dir_base, 'fixed_pattern/spatial_orientation.h5')
-    file_dot_locs = join(dir_base, 'fixed_pattern/dot_locations_printed_target.h5')
+    file_dot_locs = join(
+        dir_base, 'fixed_pattern/dot_locations_printed_target.h5')
     file_meas = join(dir_base, 'fixed_pattern/measurement_printed_target_1.h5')
     dir_output = join(dirname(__file__), 'data/output/printed_target')
 

--- a/example/fixed_pattern_deflectometry/run_fixed_pattern_projection.py
+++ b/example/fixed_pattern_deflectometry/run_fixed_pattern_projection.py
@@ -2,14 +2,14 @@
 
 NOTE: This example requires a computer screen
 """
-from os.path import join, dirname
+from os.path import join
 
 import pytest
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternScreenProjection import (
     FixedPatternScreenProjection,
 )
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.ImageProjection import ImageProjection
 
 

--- a/example/fixed_pattern_deflectometry/run_fixed_pattern_projection.py
+++ b/example/fixed_pattern_deflectometry/run_fixed_pattern_projection.py
@@ -6,7 +6,7 @@ from os.path import join, dirname
 
 import pytest
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternScreenProjection import (
     FixedPatternScreenProjection,
 )

--- a/example/fixed_pattern_deflectometry/run_fixed_pattern_projection.py
+++ b/example/fixed_pattern_deflectometry/run_fixed_pattern_projection.py
@@ -18,7 +18,7 @@ def example_project_fixed_pattern():
     """Projects fixed pattern image on display"""
     # Set pattern parameters
     file_image_projection = join(
-        dirname(opencsp.__file__),
+        opencsp_code_dir(),
         "test/data/sofast_measurements/general/Image_Projection_test.h5",
     )
     width_pattern = 3

--- a/example/scene_reconstruction/example_scene_reconstruction.py
+++ b/example/scene_reconstruction/example_scene_reconstruction.py
@@ -3,10 +3,10 @@ from os.path import join
 
 import numpy as np
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.scene_reconstruction.lib.SceneReconstruction import SceneReconstruction
 from opencsp.common.lib.camera.Camera import Camera
 from opencsp.common.lib.geometry.Vxyz import Vxyz
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 
 
 def example_scene_reconstruction():

--- a/example/scene_reconstruction/example_scene_reconstruction.py
+++ b/example/scene_reconstruction/example_scene_reconstruction.py
@@ -3,7 +3,7 @@ from os.path import join
 
 import numpy as np
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.scene_reconstruction.lib.SceneReconstruction import SceneReconstruction
 from opencsp.common.lib.camera.Camera import Camera
 from opencsp.common.lib.geometry.Vxyz import Vxyz
@@ -13,7 +13,7 @@ def example_scene_reconstruction():
     """Example script that reconstructs the XYZ locations of Aruco markers in a scene."""
     # Define input directory
     dir_input = join(
-        os.path.dirname(opencsp.__file__),
+        opencsp_code_dir,
         'app/scene_reconstruction/test/data/data_measurement',
     )
 
@@ -51,7 +51,8 @@ def example_scene_reconstruction():
     # Align points
     marker_ids = alignment_points[:, 0].astype(int)
     alignment_values = Vxyz(alignment_points[:, 1:4].T)
-    cal_scene_recon.align_points(marker_ids, alignment_values, verbose=VERBOSITY)
+    cal_scene_recon.align_points(
+        marker_ids, alignment_values, verbose=VERBOSITY)
 
     # Save points as CSV
     cal_scene_recon.save_data_as_csv(join(save_dir, 'point_locations.csv'))

--- a/example/scene_reconstruction/example_scene_reconstruction.py
+++ b/example/scene_reconstruction/example_scene_reconstruction.py
@@ -51,8 +51,7 @@ def example_scene_reconstruction():
     # Align points
     marker_ids = alignment_points[:, 0].astype(int)
     alignment_values = Vxyz(alignment_points[:, 1:4].T)
-    cal_scene_recon.align_points(
-        marker_ids, alignment_values, verbose=VERBOSITY)
+    cal_scene_recon.align_points(marker_ids, alignment_values, verbose=VERBOSITY)
 
     # Save points as CSV
     cal_scene_recon.save_data_as_csv(join(save_dir, 'point_locations.csv'))
@@ -63,4 +62,4 @@ def example_scene_reconstruction():
 
 
 if __name__ == '__main__':
-    example_optics_and_ray_tracing_driver()
+    example_scene_reconstruction()

--- a/example/scene_reconstruction/example_scene_reconstruction.py
+++ b/example/scene_reconstruction/example_scene_reconstruction.py
@@ -13,7 +13,7 @@ def example_scene_reconstruction():
     """Example script that reconstructs the XYZ locations of Aruco markers in a scene."""
     # Define input directory
     dir_input = join(
-        opencsp_code_dir,
+        opencsp_code_dir(),
         'app/scene_reconstruction/test/data/data_measurement',
     )
 

--- a/example/sofast/example_multi_facet_data_process.py
+++ b/example/sofast/example_multi_facet_data_process.py
@@ -3,22 +3,21 @@ from os.path import join
 
 import matplotlib
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
-from opencsp.app.sofast.lib.visualize_setup import visualize_setup
-from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
 from opencsp.app.sofast.lib.Measurement import Measurement
-from opencsp.common.lib.deflectometry.EnsembleData import EnsembleData
-from opencsp.common.lib.deflectometry.FacetData import FacetData
 from opencsp.app.sofast.lib.Sofast import Sofast
-from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
+from opencsp.app.sofast.lib.visualize_setup import visualize_setup
 from opencsp.common.lib.camera.Camera import Camera
 from opencsp.common.lib.csp.FacetEnsemble import FacetEnsemble
+from opencsp.common.lib.deflectometry.Display import Display
+from opencsp.common.lib.deflectometry.EnsembleData import EnsembleData
+from opencsp.common.lib.deflectometry.FacetData import FacetData
+from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 import opencsp.common.lib.render.figure_management as fm
 import opencsp.common.lib.render_control.RenderControlAxis as rca
 import opencsp.common.lib.render_control.RenderControlFigure as rcfg
 import opencsp.common.lib.render_control.RenderControlMirror as rcm
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 
 
 def example_driver():
@@ -57,8 +56,7 @@ def example_driver():
     ensemble_data = EnsembleData.load_from_json(file_ensemble)
 
     # Define facet data
-    facet_data = [FacetData.load_from_json(
-        file_facet)] * ensemble_data.num_facets
+    facet_data = [FacetData.load_from_json(file_facet)] * ensemble_data.num_facets
 
     # Define surface data (plano)
     # surface_data = [dict(surface_type='plano', robust_least_squares=False, downsample=20)] * ensemble_data.num_facets
@@ -101,16 +99,14 @@ def example_driver():
     ensemble: FacetEnsemble = sofast.get_optic()
 
     # Generate plots
-    figure_control = rcfg.RenderControlFigure(
-        tile_array=(1, 1), tile_square=True)
+    figure_control = rcfg.RenderControlFigure(tile_array=(1, 1), tile_square=True)
     mirror_control = rcm.RenderControlMirror(
         centroid=True, surface_normals=True, norm_res=1
     )
     axis_control_m = rca.meters()
 
     # Visualize setup
-    fig_record = fm.setup_figure_for_3d_data(
-        figure_control, axis_control_m, title='')
+    fig_record = fm.setup_figure_for_3d_data(figure_control, axis_control_m, title='')
     spatial_ori: SpatialOrientation = sofast.data_geometry_facet[0][
         'spatial_orientation'
     ]

--- a/example/sofast/example_multi_facet_data_process.py
+++ b/example/sofast/example_multi_facet_data_process.py
@@ -33,7 +33,7 @@ def example_driver():
     """
     # Define sample data directory
     sample_data_dir = join(
-        opencsp_code_dir, 'test/data/sofast_measurements/'
+        opencsp_code_dir(), 'test/data/sofast_measurements/'
     )
 
     # Directory setup

--- a/example/sofast/example_multi_facet_data_process.py
+++ b/example/sofast/example_multi_facet_data_process.py
@@ -3,7 +3,7 @@ from os.path import join
 
 import matplotlib
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.lib.visualize_setup import visualize_setup
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
@@ -18,6 +18,7 @@ import opencsp.common.lib.render.figure_management as fm
 import opencsp.common.lib.render_control.RenderControlAxis as rca
 import opencsp.common.lib.render_control.RenderControlFigure as rcfg
 import opencsp.common.lib.render_control.RenderControlMirror as rcm
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 
 
 def example_driver():
@@ -32,7 +33,7 @@ def example_driver():
     """
     # Define sample data directory
     sample_data_dir = join(
-        os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements/'
+        opencsp_code_dir, 'test/data/sofast_measurements/'
     )
 
     # Directory setup
@@ -56,7 +57,8 @@ def example_driver():
     ensemble_data = EnsembleData.load_from_json(file_ensemble)
 
     # Define facet data
-    facet_data = [FacetData.load_from_json(file_facet)] * ensemble_data.num_facets
+    facet_data = [FacetData.load_from_json(
+        file_facet)] * ensemble_data.num_facets
 
     # Define surface data (plano)
     # surface_data = [dict(surface_type='plano', robust_least_squares=False, downsample=20)] * ensemble_data.num_facets
@@ -99,14 +101,16 @@ def example_driver():
     ensemble: FacetEnsemble = sofast.get_optic()
 
     # Generate plots
-    figure_control = rcfg.RenderControlFigure(tile_array=(1, 1), tile_square=True)
+    figure_control = rcfg.RenderControlFigure(
+        tile_array=(1, 1), tile_square=True)
     mirror_control = rcm.RenderControlMirror(
         centroid=True, surface_normals=True, norm_res=1
     )
     axis_control_m = rca.meters()
 
     # Visualize setup
-    fig_record = fm.setup_figure_for_3d_data(figure_control, axis_control_m, title='')
+    fig_record = fm.setup_figure_for_3d_data(
+        figure_control, axis_control_m, title='')
     spatial_ori: SpatialOrientation = sofast.data_geometry_facet[0][
         'spatial_orientation'
     ]

--- a/example/sofast/example_photogrammetric_calibration.py
+++ b/example/sofast/example_photogrammetric_calibration.py
@@ -36,11 +36,13 @@ def run_scene_reconstruction(dir_input: str, verbose: int) -> SceneReconstructio
 
     # Load components
     camera = Camera.load_from_hdf(file_camera)
-    known_point_locations = np.loadtxt(file_known_points, delimiter=',', skiprows=1)
+    known_point_locations = np.loadtxt(
+        file_known_points, delimiter=',', skiprows=1)
     point_pair_distances = np.loadtxt(
         file_point_pair_distances, delimiter=',', skiprows=1
     )
-    alignment_points = np.loadtxt(file_alignment_points, delimiter=',', skiprows=1)
+    alignment_points = np.loadtxt(
+        file_alignment_points, delimiter=',', skiprows=1)
 
     # Perform marker position calibration
     cal = SceneReconstruction(camera, known_point_locations, images_pattern)
@@ -71,7 +73,8 @@ def run_screen_shape_cal(
     """
     # Define input files
     resolution_xy = [100, 100]  # sample density of screen
-    file_screen_cal_point_pairs = join(dir_input, 'screen_calibration_point_pairs.csv')
+    file_screen_cal_point_pairs = join(
+        dir_input, 'screen_calibration_point_pairs.csv')
     file_camera_distortion = join(dir_input, 'camera_screen_shape.h5')
     file_image_projection = join(dir_input, 'image_projection.h5')
     files_screen_shape_measurement = glob(
@@ -85,7 +88,8 @@ def run_screen_shape_cal(
         file_screen_cal_point_pairs, delimiter=',', skiprows=1
     ).astype(int)
     camera = Camera.load_from_hdf(file_camera_distortion)
-    image_projection_data = ImageProjection.load_from_hdf(file_image_projection)
+    image_projection_data = ImageProjection.load_from_hdf(
+        file_image_projection)
 
     # Store input data in data class
     data_input = DataInput(
@@ -121,7 +125,8 @@ def run_camera_position_cal(
 
     # Perform camera position calibraiton
     cal = CalibrationCameraPosition(camera, pts_xyz_marker, corner_ids, image)
-    cal.run_calibration(verbose)
+    cal.verbose = verbose
+    cal.run_calibration()
 
     return cal
 
@@ -159,10 +164,12 @@ def example_driver():
     pts_data = cal_scene_recon.get_data()
 
     # Run screen shape calibration
-    cal_screen_shape = run_screen_shape_cal(pts_data, base_dir_sofast, VERBOSITY)
+    cal_screen_shape = run_screen_shape_cal(
+        pts_data, base_dir_sofast, VERBOSITY)
 
     # Run camera position calibration
-    cal_camera_pose = run_camera_position_cal(pts_data, base_dir_sofast, VERBOSITY)
+    cal_camera_pose = run_camera_position_cal(
+        pts_data, base_dir_sofast, VERBOSITY)
 
     # Get physical setup file data
     NAME = 'Example physical setup file'
@@ -177,12 +184,14 @@ def example_driver():
 
     # Save data
     cal_scene_recon.save_data_as_csv(join(save_dir, 'point_locations.csv'))
-    cal_screen_shape.save_data_as_hdf(join(save_dir, 'screen_distortion_data.h5'))
+    cal_screen_shape.save_data_as_hdf(
+        join(save_dir, 'screen_distortion_data.h5'))
     cal_camera_pose.save_data_as_csv(join(save_dir, 'camera_rvec_tvec.csv'))
 
     # Save display file
     file_save = join(save_dir, 'example_physical_setup_file.h5')
-    save_physical_setup_file(screen_distortion_data, NAME, rvec, tvec, file_save)
+    save_physical_setup_file(screen_distortion_data,
+                             NAME, rvec, tvec, file_save)
 
 
 if __name__ == '__main__':

--- a/example/sofast/example_photogrammetric_calibration.py
+++ b/example/sofast/example_photogrammetric_calibration.py
@@ -6,7 +6,7 @@ import matplotlib
 import numpy as np
 from numpy import ndarray
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.scene_reconstruction.lib.SceneReconstruction import SceneReconstruction
 from opencsp.common.lib.deflectometry.CalibrationCameraPosition import (
     CalibrationCameraPosition,
@@ -142,11 +142,11 @@ def example_driver():
     """
     # Define input file directories
     base_dir_scene_recon = join(
-        os.path.dirname(opencsp.__file__),
+        opencsp_code_dir,
         'app/scene_reconstruction/test/data/data_measurement',
     )  # low-res test data
     base_dir_sofast = join(
-        os.path.dirname(opencsp.__file__),
+        opencsp_code_dir,
         'common/lib/deflectometry/test/data/data_measurement',
     )  # low-res test data
 

--- a/example/sofast/example_photogrammetric_calibration.py
+++ b/example/sofast/example_photogrammetric_calibration.py
@@ -6,8 +6,8 @@ import matplotlib
 import numpy as np
 from numpy import ndarray
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.scene_reconstruction.lib.SceneReconstruction import SceneReconstruction
+from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.common.lib.deflectometry.CalibrationCameraPosition import (
     CalibrationCameraPosition,
 )
@@ -18,10 +18,10 @@ from opencsp.app.sofast.calibration.lib.CalibrationScreenShape import (
 from opencsp.app.sofast.calibration.lib.save_physical_setup_file import (
     save_physical_setup_file,
 )
-from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.common.lib.camera.Camera import Camera
 from opencsp.common.lib.deflectometry.ImageProjection import ImageProjection
 from opencsp.common.lib.geometry.Vxyz import Vxyz
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.photogrammetry.photogrammetry import load_image_grayscale
 
 
@@ -36,13 +36,11 @@ def run_scene_reconstruction(dir_input: str, verbose: int) -> SceneReconstructio
 
     # Load components
     camera = Camera.load_from_hdf(file_camera)
-    known_point_locations = np.loadtxt(
-        file_known_points, delimiter=',', skiprows=1)
+    known_point_locations = np.loadtxt(file_known_points, delimiter=',', skiprows=1)
     point_pair_distances = np.loadtxt(
         file_point_pair_distances, delimiter=',', skiprows=1
     )
-    alignment_points = np.loadtxt(
-        file_alignment_points, delimiter=',', skiprows=1)
+    alignment_points = np.loadtxt(file_alignment_points, delimiter=',', skiprows=1)
 
     # Perform marker position calibration
     cal = SceneReconstruction(camera, known_point_locations, images_pattern)
@@ -73,8 +71,7 @@ def run_screen_shape_cal(
     """
     # Define input files
     resolution_xy = [100, 100]  # sample density of screen
-    file_screen_cal_point_pairs = join(
-        dir_input, 'screen_calibration_point_pairs.csv')
+    file_screen_cal_point_pairs = join(dir_input, 'screen_calibration_point_pairs.csv')
     file_camera_distortion = join(dir_input, 'camera_screen_shape.h5')
     file_image_projection = join(dir_input, 'image_projection.h5')
     files_screen_shape_measurement = glob(
@@ -88,8 +85,7 @@ def run_screen_shape_cal(
         file_screen_cal_point_pairs, delimiter=',', skiprows=1
     ).astype(int)
     camera = Camera.load_from_hdf(file_camera_distortion)
-    image_projection_data = ImageProjection.load_from_hdf(
-        file_image_projection)
+    image_projection_data = ImageProjection.load_from_hdf(file_image_projection)
 
     # Store input data in data class
     data_input = DataInput(
@@ -164,12 +160,10 @@ def example_driver():
     pts_data = cal_scene_recon.get_data()
 
     # Run screen shape calibration
-    cal_screen_shape = run_screen_shape_cal(
-        pts_data, base_dir_sofast, VERBOSITY)
+    cal_screen_shape = run_screen_shape_cal(pts_data, base_dir_sofast, VERBOSITY)
 
     # Run camera position calibration
-    cal_camera_pose = run_camera_position_cal(
-        pts_data, base_dir_sofast, VERBOSITY)
+    cal_camera_pose = run_camera_position_cal(pts_data, base_dir_sofast, VERBOSITY)
 
     # Get physical setup file data
     NAME = 'Example physical setup file'
@@ -184,14 +178,12 @@ def example_driver():
 
     # Save data
     cal_scene_recon.save_data_as_csv(join(save_dir, 'point_locations.csv'))
-    cal_screen_shape.save_data_as_hdf(
-        join(save_dir, 'screen_distortion_data.h5'))
+    cal_screen_shape.save_data_as_hdf(join(save_dir, 'screen_distortion_data.h5'))
     cal_camera_pose.save_data_as_csv(join(save_dir, 'camera_rvec_tvec.csv'))
 
     # Save display file
     file_save = join(save_dir, 'example_physical_setup_file.h5')
-    save_physical_setup_file(screen_distortion_data,
-                             NAME, rvec, tvec, file_save)
+    save_physical_setup_file(screen_distortion_data, NAME, rvec, tvec, file_save)
 
 
 if __name__ == '__main__':

--- a/example/sofast/example_photogrammetric_calibration.py
+++ b/example/sofast/example_photogrammetric_calibration.py
@@ -142,11 +142,11 @@ def example_driver():
     """
     # Define input file directories
     base_dir_scene_recon = join(
-        opencsp_code_dir,
+        opencsp_code_dir(),
         'app/scene_reconstruction/test/data/data_measurement',
     )  # low-res test data
     base_dir_sofast = join(
-        opencsp_code_dir,
+        opencsp_code_dir(),
         'common/lib/deflectometry/test/data/data_measurement',
     )  # low-res test data
 

--- a/example/sofast/example_single_facet_data_process.py
+++ b/example/sofast/example_single_facet_data_process.py
@@ -3,7 +3,7 @@ from os.path import join
 
 import matplotlib
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.lib.visualize_setup import visualize_setup
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.common.lib.deflectometry.FacetData import FacetData
@@ -30,7 +30,7 @@ def example_driver():
     """
     # Define sample data directory
     sample_data_dir = join(
-        os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements/'
+        opencsp_code_dir, 'test/data/sofast_measurements/'
     )
 
     # Directory Setup
@@ -81,14 +81,16 @@ def example_driver():
     facet: Facet = sofast.get_optic()
 
     # Generate plots
-    figure_control = rcfg.RenderControlFigure(tile_array=(1, 1), tile_square=True)
+    figure_control = rcfg.RenderControlFigure(
+        tile_array=(1, 1), tile_square=True)
     mirror_control = rcm.RenderControlMirror(
         centroid=True, surface_normals=True, norm_res=1
     )
     axis_control_m = rca.meters()
 
     # Visualize setup
-    fig_record = fm.setup_figure_for_3d_data(figure_control, axis_control_m, title='')
+    fig_record = fm.setup_figure_for_3d_data(
+        figure_control, axis_control_m, title='')
     spatial_ori: SpatialOrientation = sofast.data_geometry_facet[0].spatial_orientation
     visualize_setup(
         display,

--- a/example/sofast/example_single_facet_data_process.py
+++ b/example/sofast/example_single_facet_data_process.py
@@ -30,7 +30,7 @@ def example_driver():
     """
     # Define sample data directory
     sample_data_dir = join(
-        opencsp_code_dir, 'test/data/sofast_measurements/'
+        opencsp_code_dir(), 'test/data/sofast_measurements/'
     )
 
     # Directory Setup

--- a/example/sofast/example_single_facet_data_process.py
+++ b/example/sofast/example_single_facet_data_process.py
@@ -3,20 +3,19 @@ from os.path import join
 
 import matplotlib
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
-from opencsp.app.sofast.lib.visualize_setup import visualize_setup
-from opencsp.common.lib.deflectometry.Display import Display
-from opencsp.common.lib.deflectometry.FacetData import FacetData
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
 from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.app.sofast.lib.Sofast import Sofast
-from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
+from opencsp.app.sofast.lib.visualize_setup import visualize_setup
 from opencsp.common.lib.camera.Camera import Camera
 from opencsp.common.lib.csp.Facet import Facet
+from opencsp.common.lib.deflectometry.Display import Display
+from opencsp.common.lib.deflectometry.FacetData import FacetData
+from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 import opencsp.common.lib.render.figure_management as fm
 import opencsp.common.lib.render_control.RenderControlAxis as rca
 import opencsp.common.lib.render_control.RenderControlFigure as rcfg
-import opencsp.common.lib.render_control.RenderControlMirror as rcm
 
 
 def example_driver():
@@ -81,16 +80,11 @@ def example_driver():
     facet: Facet = sofast.get_optic()
 
     # Generate plots
-    figure_control = rcfg.RenderControlFigure(
-        tile_array=(1, 1), tile_square=True)
-    mirror_control = rcm.RenderControlMirror(
-        centroid=True, surface_normals=True, norm_res=1
-    )
+    figure_control = rcfg.RenderControlFigure(tile_array=(1, 1), tile_square=True)
     axis_control_m = rca.meters()
 
     # Visualize setup
-    fig_record = fm.setup_figure_for_3d_data(
-        figure_control, axis_control_m, title='')
+    fig_record = fm.setup_figure_for_3d_data(figure_control, axis_control_m, title='')
     spatial_ori: SpatialOrientation = sofast.data_geometry_facet[0].spatial_orientation
     visualize_setup(
         display,

--- a/example/sofast/example_standard_mirror_plot_output.py
+++ b/example/sofast/example_standard_mirror_plot_output.py
@@ -3,12 +3,12 @@ from os.path import join
 
 from scipy.spatial.transform import Rotation
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 import opencsp.app.sofast.lib.load_saved_data as lsd
 import opencsp.common.lib.csp.standard_output as so
 from opencsp.common.lib.csp.LightSourceSun import LightSourceSun
 from opencsp.common.lib.geometry.Uxyz import Uxyz
 from opencsp.common.lib.geometry.Vxyz import Vxyz
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 
 
 def plot_sofast_single_facet(
@@ -28,14 +28,12 @@ def plot_sofast_single_facet(
     """
     # Load data
     optic_meas = lsd.load_facet_from_hdf(data_file)
-    optic_ref = lsd.load_ideal_facet_from_hdf(
-        data_file, focal_length_paraboloid)
+    optic_ref = lsd.load_ideal_facet_from_hdf(data_file, focal_length_paraboloid)
 
     # Define scene
     v_target_center = Vxyz((0, 0, 56.57))
     v_target_normal = Vxyz((0, 1, 0))
-    source = LightSourceSun.from_given_sun_position(
-        Uxyz((0, 0, -1)), resolution=20)
+    source = LightSourceSun.from_given_sun_position(Uxyz((0, 0, -1)), resolution=20)
 
     # Define reference optic position/orientation
     rot = Rotation.from_euler('x', [22.5], degrees=True)
@@ -82,8 +80,7 @@ def plot_sofast_facet_ensemble(
     # Define scene
     v_target_center = Vxyz((0, 0, 56.57))
     v_target_normal = Vxyz((0, 1, 0))
-    source = LightSourceSun.from_given_sun_position(
-        Uxyz((0, 0, -1)), resolution=20)
+    source = LightSourceSun.from_given_sun_position(Uxyz((0, 0, -1)), resolution=20)
 
     # Define reference optic position/orientation
     rot = Rotation.from_euler('x', [22.5], degrees=True)

--- a/example/sofast/example_standard_mirror_plot_output.py
+++ b/example/sofast/example_standard_mirror_plot_output.py
@@ -130,7 +130,7 @@ def example_driver():
     """
     # Define measured and reference data
     sample_data_dir = join(
-        opencsp_code_dir, 'test/data/sofast_measurements/'
+        opencsp_code_dir(), 'test/data/sofast_measurements/'
     )
 
     save_dir = join(os.path.dirname(__file__), 'data/output/standard_output')

--- a/example/sofast/example_standard_mirror_plot_output.py
+++ b/example/sofast/example_standard_mirror_plot_output.py
@@ -3,7 +3,7 @@ from os.path import join
 
 from scipy.spatial.transform import Rotation
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 import opencsp.app.sofast.lib.load_saved_data as lsd
 import opencsp.common.lib.csp.standard_output as so
 from opencsp.common.lib.csp.LightSourceSun import LightSourceSun
@@ -28,12 +28,14 @@ def plot_sofast_single_facet(
     """
     # Load data
     optic_meas = lsd.load_facet_from_hdf(data_file)
-    optic_ref = lsd.load_ideal_facet_from_hdf(data_file, focal_length_paraboloid)
+    optic_ref = lsd.load_ideal_facet_from_hdf(
+        data_file, focal_length_paraboloid)
 
     # Define scene
     v_target_center = Vxyz((0, 0, 56.57))
     v_target_normal = Vxyz((0, 1, 0))
-    source = LightSourceSun.from_given_sun_position(Uxyz((0, 0, -1)), resolution=20)
+    source = LightSourceSun.from_given_sun_position(
+        Uxyz((0, 0, -1)), resolution=20)
 
     # Define reference optic position/orientation
     rot = Rotation.from_euler('x', [22.5], degrees=True)
@@ -80,7 +82,8 @@ def plot_sofast_facet_ensemble(
     # Define scene
     v_target_center = Vxyz((0, 0, 56.57))
     v_target_normal = Vxyz((0, 1, 0))
-    source = LightSourceSun.from_given_sun_position(Uxyz((0, 0, -1)), resolution=20)
+    source = LightSourceSun.from_given_sun_position(
+        Uxyz((0, 0, -1)), resolution=20)
 
     # Define reference optic position/orientation
     rot = Rotation.from_euler('x', [22.5], degrees=True)
@@ -127,7 +130,7 @@ def example_driver():
     """
     # Define measured and reference data
     sample_data_dir = join(
-        os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements/'
+        opencsp_code_dir, 'test/data/sofast_measurements/'
     )
 
     save_dir = join(os.path.dirname(__file__), 'data/output/standard_output')

--- a/example/sofast/example_undefined_facet_data_process.py
+++ b/example/sofast/example_undefined_facet_data_process.py
@@ -1,19 +1,18 @@
 import os
 from os.path import join
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.lib.visualize_setup import visualize_setup
-from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
 from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.app.sofast.lib.Sofast import Sofast
+from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
 from opencsp.common.lib.camera.Camera import Camera
 from opencsp.common.lib.csp.Facet import Facet
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 import opencsp.common.lib.render.figure_management as fm
 import opencsp.common.lib.render_control.RenderControlAxis as rca
 import opencsp.common.lib.render_control.RenderControlFigure as rcfg
-import opencsp.common.lib.render_control.RenderControlMirror as rcm
 
 
 def example_driver():
@@ -77,16 +76,11 @@ def example_driver():
     facet: Facet = sofast.get_optic()
 
     # Generate plots
-    figure_control = rcfg.RenderControlFigure(
-        tile_array=(1, 1), tile_square=True)
-    mirror_control = rcm.RenderControlMirror(
-        centroid=True, surface_normals=True, norm_res=1
-    )
+    figure_control = rcfg.RenderControlFigure(tile_array=(1, 1), tile_square=True)
     axis_control_m = rca.meters()
 
     # Visualize setup
-    fig_record = fm.setup_figure_for_3d_data(
-        figure_control, axis_control_m, title='')
+    fig_record = fm.setup_figure_for_3d_data(figure_control, axis_control_m, title='')
     spatial_ori: SpatialOrientation = sofast.data_geometry_facet[0].spatial_orientation
     visualize_setup(
         display,

--- a/example/sofast/example_undefined_facet_data_process.py
+++ b/example/sofast/example_undefined_facet_data_process.py
@@ -27,7 +27,7 @@ def example_driver():
     """
     # Define sample data directory
     sample_data_dir = join(
-        opencsp_code_dir, 'test/data/sofast_measurements/'
+        opencsp_code_dir(), 'test/data/sofast_measurements/'
     )
 
     # Directory Setup

--- a/example/sofast/example_undefined_facet_data_process.py
+++ b/example/sofast/example_undefined_facet_data_process.py
@@ -1,7 +1,7 @@
 import os
 from os.path import join
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.lib.visualize_setup import visualize_setup
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
@@ -27,7 +27,7 @@ def example_driver():
     """
     # Define sample data directory
     sample_data_dir = join(
-        os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements/'
+        opencsp_code_dir, 'test/data/sofast_measurements/'
     )
 
     # Directory Setup
@@ -77,14 +77,16 @@ def example_driver():
     facet: Facet = sofast.get_optic()
 
     # Generate plots
-    figure_control = rcfg.RenderControlFigure(tile_array=(1, 1), tile_square=True)
+    figure_control = rcfg.RenderControlFigure(
+        tile_array=(1, 1), tile_square=True)
     mirror_control = rcm.RenderControlMirror(
         centroid=True, surface_normals=True, norm_res=1
     )
     axis_control_m = rca.meters()
 
     # Visualize setup
-    fig_record = fm.setup_figure_for_3d_data(figure_control, axis_control_m, title='')
+    fig_record = fm.setup_figure_for_3d_data(
+        figure_control, axis_control_m, title='')
     spatial_ori: SpatialOrientation = sofast.data_geometry_facet[0].spatial_orientation
     visualize_setup(
         display,

--- a/example/sofast/example_view_camera_distortion.py
+++ b/example/sofast/example_view_camera_distortion.py
@@ -17,7 +17,7 @@ def example_driver():
     """
     # Define input camera file
     file = os.path.join(
-        opencsp_code_dir, 'test/data/sofast_measurements/camera.h5'
+        opencsp_code_dir(), 'test/data/sofast_measurements/camera.h5'
     )
 
     # Load camera

--- a/example/sofast/example_view_camera_distortion.py
+++ b/example/sofast/example_view_camera_distortion.py
@@ -2,7 +2,7 @@ import os
 
 import matplotlib.pyplot as plt
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.camera_calibration.lib.calibration_camera import view_distortion
 from opencsp.common.lib.camera.Camera import Camera
 
@@ -17,7 +17,7 @@ def example_driver():
     """
     # Define input camera file
     file = os.path.join(
-        os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements/camera.h5'
+        opencsp_code_dir, 'test/data/sofast_measurements/camera.h5'
     )
 
     # Load camera
@@ -33,7 +33,8 @@ def example_driver():
     view_distortion(cam, ax1, ax2, ax3)
 
     # Save image
-    dir_save = os.path.join(os.path.dirname(__file__), 'data/output/camera_distortion')
+    dir_save = os.path.join(os.path.dirname(__file__),
+                            'data/output/camera_distortion')
     if not os.path.exists(dir_save):
         os.makedirs(dir_save)
     fig.savefig(os.path.join(dir_save, 'distortion_plot.png'))

--- a/example/sofast/example_view_camera_distortion.py
+++ b/example/sofast/example_view_camera_distortion.py
@@ -2,9 +2,9 @@ import os
 
 import matplotlib.pyplot as plt
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.camera_calibration.lib.calibration_camera import view_distortion
 from opencsp.common.lib.camera.Camera import Camera
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 
 
 def example_driver():
@@ -33,8 +33,7 @@ def example_driver():
     view_distortion(cam, ax1, ax2, ax3)
 
     # Save image
-    dir_save = os.path.join(os.path.dirname(__file__),
-                            'data/output/camera_distortion')
+    dir_save = os.path.join(os.path.dirname(__file__), 'data/output/camera_distortion')
     if not os.path.exists(dir_save):
         os.makedirs(dir_save)
     fig.savefig(os.path.join(dir_save, 'distortion_plot.png'))

--- a/opencsp/app/fixed_pattern_deflectometry/lib/FixedPatternSetupCalibrate.py
+++ b/opencsp/app/fixed_pattern_deflectometry/lib/FixedPatternSetupCalibrate.py
@@ -173,10 +173,8 @@ class FixedPatternSetupCalibrate:
         self._dot_image_points_indices = Vxy((indices_x, indices_y), dtype=int)
 
         # Save all indices as matrix
-        self._dot_image_points_indices_x = np.arange(
-            self._x_min, self._x_max + 1)
-        self._dot_image_points_indices_y = np.arange(
-            self._y_min, self._y_max + 1)
+        self._dot_image_points_indices_x = np.arange(self._x_min, self._x_max + 1)
+        self._dot_image_points_indices_y = np.arange(self._y_min, self._y_max + 1)
 
     def _find_markers_in_images(self) -> None:
         """Finds Aruco marker corners in images and assigns xyz points"""
@@ -193,8 +191,7 @@ class FixedPatternSetupCalibrate:
             )
             # Save corner locations and corner IDs
             marker_ids = np.repeat(ids, 4)
-            marker_corner_ids = \
-                np.repeat(ids * 4, 4) + np.tile(ids_add, ids.size)
+            marker_corner_ids = np.repeat(ids * 4, 4) + np.tile(ids_add, ids.size)
             marker_corners_xy = Vxy(np.concatenate(pts, 0).T)
 
             # Save xyz locations
@@ -288,8 +285,7 @@ class FixedPatternSetupCalibrate:
         points_xyz = []
         int_dists = []
         for dot_idx in tqdm(range(self._num_dots), desc='Intersecting rays'):
-            dot_image_pts_xy = [pt[dot_idx]
-                                for pt in self._dot_image_points_xy]
+            dot_image_pts_xy = [pt[dot_idx] for pt in self._dot_image_points_xy]
             point, dists = ph.triangulate(
                 [self._camera] * self._num_images,
                 self._rots_cams,
@@ -303,8 +299,7 @@ class FixedPatternSetupCalibrate:
                 indices = self._dot_image_points_indices[dot_idx]
                 idx_x = indices.x[0] - self._x_min
                 idx_y = indices.y[0] - self._y_min
-                self._dot_points_xyz_mat[idx_y,
-                                         idx_x, :] = point.data.squeeze()
+                self._dot_points_xyz_mat[idx_y, idx_x, :] = point.data.squeeze()
 
         self._dot_intersection_dists = np.array(int_dists)
 
@@ -312,14 +307,10 @@ class FixedPatternSetupCalibrate:
         """Prints ray intersection mean, average, and standard deviation
         """
         print('Dot ray intersections:')
-        print(
-            f'   Mean intersection error: {self._dot_intersection_dists.mean() * 1000:.1f} mm')
-        print(
-            f'   Min intersection error: {self._dot_intersection_dists.min() * 1000:.1f} mm')
-        print(
-            f'   Max intersection error: {self._dot_intersection_dists.max() * 1000:.1f} mm')
-        print(
-            f'   STDEV of intersection errors: {self._dot_intersection_dists.std() * 1000:.1f} mm')
+        print(f'   Mean intersection error: {self._dot_intersection_dists.mean() * 1000:.1f} mm')
+        print(f'   Min intersection error: {self._dot_intersection_dists.min() * 1000:.1f} mm')
+        print(f'   Max intersection error: {self._dot_intersection_dists.max() * 1000:.1f} mm')
+        print(f'   STDEV of intersection error: {self._dot_intersection_dists.std() * 1000:.1f} mm')
 
     def _plot_common_dots(self) -> None:
         """Plots common dots on images"""

--- a/opencsp/app/fixed_pattern_deflectometry/lib/FixedPatternSetupCalibrate.py
+++ b/opencsp/app/fixed_pattern_deflectometry/lib/FixedPatternSetupCalibrate.py
@@ -108,6 +108,7 @@ class FixedPatternSetupCalibrate:
             np.ndarray((x_max - x_min + 1, y_max - y_min + 1, 3)) * np.nan
         )
         self._num_dots: int
+        self._marker_corner_idxs: list[ndarray] = []
         self._marker_ids: list[ndarray] = []
         self._marker_corner_ids: list[ndarray] = []
         self._marker_corners_xy: list[Vxy] = []
@@ -115,6 +116,16 @@ class FixedPatternSetupCalibrate:
         self._rots_cams: list[ndarray] = []
         self._vecs_cams: list[ndarray] = []
         self._dot_intersection_dists: ndarray
+
+    @property
+    def _to_print(self) -> bool:
+        """If verbose printing is turned on"""
+        return self.verbose in [1, 2]
+
+    @property
+    def _to_plot(self) -> bool:
+        """If verbose plotting is turned on"""
+        return self.verbose in [2, 3]
 
     def _find_dots_in_images(self) -> None:
         """Finds dot locations for several camera poses"""
@@ -162,8 +173,10 @@ class FixedPatternSetupCalibrate:
         self._dot_image_points_indices = Vxy((indices_x, indices_y), dtype=int)
 
         # Save all indices as matrix
-        self._dot_image_points_indices_x = np.arange(self._x_min, self._x_max + 1)
-        self._dot_image_points_indices_y = np.arange(self._y_min, self._y_max + 1)
+        self._dot_image_points_indices_x = np.arange(
+            self._x_min, self._x_max + 1)
+        self._dot_image_points_indices_y = np.arange(
+            self._y_min, self._y_max + 1)
 
     def _find_markers_in_images(self) -> None:
         """Finds Aruco marker corners in images and assigns xyz points"""
@@ -178,21 +191,52 @@ class FixedPatternSetupCalibrate:
                 self.marker_detection_params['adaptive_thresh_constant'],
                 self.marker_detection_params['min_marker_perimeter_rate'],
             )
-            # Save point locations and IDs
+            # Save corner locations and corner IDs
             marker_ids = np.repeat(ids, 4)
-            marker_corner_ids = np.repeat(ids * 4, 4) + np.tile(ids_add, ids.size)
+            marker_corner_ids = \
+                np.repeat(ids * 4, 4) + np.tile(ids_add, ids.size)
             marker_corners_xy = Vxy(np.concatenate(pts, 0).T)
-            # Save xyz locations
-            point_idxs = []
-            for marker_corner_id in marker_corner_ids:
-                point_idxs.append(
-                    np.where(self._pts_ids_corners == marker_corner_id)[0][0]
-                )
 
-            self._marker_ids.append(marker_ids)
-            self._marker_corner_ids.append(marker_corner_ids)
-            self._marker_corners_xy.append(marker_corners_xy)
-            self._marker_corners_xyz.append(self._pts_xyz_corners[point_idxs])
+            # Save xyz locations
+            marker_corner_ids_cur = []
+            marker_ids_cur = []
+            marker_corner_xy_cur = []
+            marker_corner_xyz_cur = []
+            marker_corner_idxs_cur = []
+            for marker_corner_id, marker_id, marker_corner_xy in zip(marker_corner_ids, marker_ids, marker_corners_xy):
+                # Loop up found marker corner ID
+                idx_mkr_corner = np.where(
+                    self._pts_ids_corners == marker_corner_id)[0]
+
+                # Check marker corner ID is in given list of marker corner IDs
+                if idx_mkr_corner.size == 0:
+                    if self._to_print:
+                        print(
+                            f'Found marker corner ID, {marker_corner_id:d}, is not in given marker corner IDs. This point will be skipped.')
+                    continue
+
+                # Check found marker corner ID is assigned a non-nan value in given marker locations
+                if np.any(np.isnan(self._pts_xyz_corners[idx_mkr_corner[0]].data)):
+                    if self._to_print:
+                        print(
+                            f'Point ID {idx_mkr_corner[0]:d} undefined, point will be skipped')
+                    continue
+
+                # Save marker corner ID
+                marker_corner_idxs_cur.append(idx_mkr_corner[0])
+                marker_corner_ids_cur.append(marker_corner_id)
+                marker_ids_cur.append(marker_id)
+                marker_corner_xy_cur.append(marker_corner_xy.data)
+                marker_corner_xyz_cur.append(
+                    self._pts_xyz_corners[idx_mkr_corner[0]].data)
+
+            self._marker_corner_idxs.append(np.array(marker_corner_idxs_cur))
+            self._marker_ids.append(np.array(marker_ids_cur))
+            self._marker_corner_ids.append(np.array(marker_corner_ids_cur))
+            self._marker_corners_xy.append(
+                Vxy(np.concatenate(marker_corner_xy_cur, axis=1)))
+            self._marker_corners_xyz.append(
+                Vxyz(np.concatenate(marker_corner_xyz_cur, axis=1)))
 
     def _calculate_camera_poses(self) -> None:
         """Calculates 3d camera poses"""
@@ -217,12 +261,35 @@ class FixedPatternSetupCalibrate:
             self._rots_cams.append(Rotation.from_rotvec(rvec.squeeze()))
             self._vecs_cams.append(Vxyz(tvec))
 
+    def _print_camera_pose_reprojection_errors(self) -> None:
+        """Prints reprojection errors after finding camera
+        """
+        for idx_cam in range(len(self._images)):
+            # Collect inputs
+            rvecs = self._rots_cams[idx_cam].as_rotvec()[None, :]
+            tvecs = self._vecs_cams[idx_cam].data.T
+            pts_obj = self._pts_xyz_corners.data.T
+            camera_indices = np.zeros(
+                self._marker_corner_ids[idx_cam].size, dtype=int)
+            point_indices = self._marker_corner_idxs[idx_cam]
+            points2d = self._marker_corners_xy[idx_cam].data.T
+
+            # Calculate errors
+            errors = ph.reprojection_errors(
+                rvecs, tvecs, pts_obj, self._camera, camera_indices, point_indices, points2d)
+            errors = Vxy(errors.T)
+
+            # Print errors
+            print(
+                f'Camera {idx_cam:d} average marker reprojection error: {errors.magnitude().mean():.2f} pixels')
+
     def _intersect_rays(self) -> None:
         """Intersects camera rays to find dot xyz locations"""
         points_xyz = []
         int_dists = []
         for dot_idx in tqdm(range(self._num_dots), desc='Intersecting rays'):
-            dot_image_pts_xy = [pt[dot_idx] for pt in self._dot_image_points_xy]
+            dot_image_pts_xy = [pt[dot_idx]
+                                for pt in self._dot_image_points_xy]
             point, dists = ph.triangulate(
                 [self._camera] * self._num_images,
                 self._rots_cams,
@@ -236,9 +303,23 @@ class FixedPatternSetupCalibrate:
                 indices = self._dot_image_points_indices[dot_idx]
                 idx_x = indices.x[0] - self._x_min
                 idx_y = indices.y[0] - self._y_min
-                self._dot_points_xyz_mat[idx_y, idx_x, :] = point.data.squeeze()
+                self._dot_points_xyz_mat[idx_y,
+                                         idx_x, :] = point.data.squeeze()
 
         self._dot_intersection_dists = np.array(int_dists)
+
+    def _print_ray_intersection_statistics(self):
+        """Prints ray intersection mean, average, and standard deviation
+        """
+        print('Dot ray intersections:')
+        print(
+            f'   Mean intersection error: {self._dot_intersection_dists.mean() * 1000:.1f} mm')
+        print(
+            f'   Min intersection error: {self._dot_intersection_dists.min() * 1000:.1f} mm')
+        print(
+            f'   Max intersection error: {self._dot_intersection_dists.max() * 1000:.1f} mm')
+        print(
+            f'   STDEV of intersection errors: {self._dot_intersection_dists.std() * 1000:.1f} mm')
 
     def _plot_common_dots(self) -> None:
         """Plots common dots on images"""
@@ -344,11 +425,18 @@ class FixedPatternSetupCalibrate:
     def run(self) -> None:
         """Runs full calibration sequence"""
         self._find_dots_in_images()
-        self._find_markers_in_images()
-        self._calculate_camera_poses()
-        self._intersect_rays()
 
-        if self.verbose in [2, 3]:
+        self._find_markers_in_images()
+
+        self._calculate_camera_poses()
+        if self._to_print:
+            self._print_camera_pose_reprojection_errors()
+
+        self._intersect_rays()
+        if self._to_print:
+            self._print_ray_intersection_statistics()
+
+        if self._to_plot:
             self._plot_common_dots()
             self._plot_marker_corners()
             self._plot_located_cameras_and_points()

--- a/opencsp/app/fixed_pattern_deflectometry/lib/FixedPatternSetupCalibrate.py
+++ b/opencsp/app/fixed_pattern_deflectometry/lib/FixedPatternSetupCalibrate.py
@@ -26,7 +26,8 @@ class FixedPatternSetupCalibrate:
 
     Attributes
     ----------
-    - verbose : 0=no output, 1=print only output, 2=print and plot output, 3=only plot output
+    - print : bool, to print outputs
+    - plot : bool, to plot outputs
     - intersection_threshold : threshold to consider a ray intersection a success or not (meters)
     - figures : list of figures produced
     - marker_detection_params : parameters used in detecting Aruco markers in images
@@ -79,7 +80,8 @@ class FixedPatternSetupCalibrate:
         self._num_images = len(images)
 
         # Settings
-        self.verbose = 0
+        self.print = False
+        self.plot = False
         self.intersection_threshold = 0.002  # meters
         self.figures = []
         self.marker_detection_params = {
@@ -117,22 +119,12 @@ class FixedPatternSetupCalibrate:
         self._vecs_cams: list[ndarray] = []
         self._dot_intersection_dists: ndarray
 
-    @property
-    def _to_print(self) -> bool:
-        """If verbose printing is turned on"""
-        return self.verbose in [1, 2]
-
-    @property
-    def _to_plot(self) -> bool:
-        """If verbose plotting is turned on"""
-        return self.verbose in [2, 3]
-
     def _find_dots_in_images(self) -> None:
         """Finds dot locations for several camera poses"""
         dot_image_points_xy_mat = []
         masks_unassigned = []
         for idx, (image, origin_pt) in enumerate(zip(self._images, self._origin_pts)):
-            if self.verbose in [1, 2]:
+            if self.print:
                 print(f'Finding dots in image: {idx:d}')
 
             # Find blobs
@@ -180,7 +172,7 @@ class FixedPatternSetupCalibrate:
         """Finds Aruco marker corners in images and assigns xyz points"""
         ids_add = np.array([0, 1, 2, 3])
         for idx, image in enumerate(self._images):
-            if self.verbose in [1, 2]:
+            if self.print:
                 print(f'Finding marker corners in image: {idx:d}')
 
             # Find markers in image
@@ -207,14 +199,14 @@ class FixedPatternSetupCalibrate:
 
                 # Check marker corner ID is in given list of marker corner IDs
                 if idx_mkr_corner.size == 0:
-                    if self._to_print:
+                    if self.print:
                         print(
                             f'Found marker corner ID, {marker_corner_id:d}, is not in given marker corner IDs. This point will be skipped.')
                     continue
 
                 # Check found marker corner ID is assigned a non-nan value in given marker locations
                 if np.any(np.isnan(self._pts_xyz_corners[idx_mkr_corner[0]].data)):
-                    if self._to_print:
+                    if self.print:
                         print(
                             f'Point ID {idx_mkr_corner[0]:d} undefined, point will be skipped')
                     continue
@@ -238,7 +230,7 @@ class FixedPatternSetupCalibrate:
     def _calculate_camera_poses(self) -> None:
         """Calculates 3d camera poses"""
         for cam_idx in range(self._num_images):
-            if self.verbose in [0, 2]:
+            if self.print:
                 print(
                     f'Calculating camera {cam_idx:d} pose with {len(self._marker_corners_xyz[cam_idx]):d} points'
                 )
@@ -420,14 +412,14 @@ class FixedPatternSetupCalibrate:
         self._find_markers_in_images()
 
         self._calculate_camera_poses()
-        if self._to_print:
+        if self.print:
             self._print_camera_pose_reprojection_errors()
 
         self._intersect_rays()
-        if self._to_print:
+        if self.print:
             self._print_ray_intersection_statistics()
 
-        if self._to_plot:
+        if self.plot:
             self._plot_common_dots()
             self._plot_marker_corners()
             self._plot_located_cameras_and_points()

--- a/opencsp/app/fixed_pattern_deflectometry/lib/FixedPatternSetupCalibrate.py
+++ b/opencsp/app/fixed_pattern_deflectometry/lib/FixedPatternSetupCalibrate.py
@@ -81,7 +81,6 @@ class FixedPatternSetupCalibrate:
                 im.set_point_id_located(pt_id, pt_xyz.data.squeeze())
 
         # Save data
-        self._images_array = [image.image for image in self._images]
         self._origin_pts = origin_pts
         self._camera = camera
         self._pts_xyz_corners = pts_xyz_corners
@@ -127,11 +126,11 @@ class FixedPatternSetupCalibrate:
         """Finds dot locations for several camera poses"""
         dot_image_points_xy_mat = []
         masks_unassigned = []
-        for idx, (image, origin_pt) in enumerate(zip(self._images_array, self._origin_pts)):
-            lt.info(f'Finding dots in image: {idx:d}')
+        for idx_image, origin_pt in enumerate(self._origin_pts):
+            lt.info(f'Finding dots in image: {idx_image:d}')
 
             # Find blobs
-            pts = ip.detect_blobs(image, self.blob_detector)
+            pts = ip.detect_blobs(self._images[idx_image].image, self.blob_detector)
 
             # Index all found points
             blob_index = BlobIndex(
@@ -225,21 +224,19 @@ class FixedPatternSetupCalibrate:
 
     def _plot_common_dots(self) -> None:
         """Plots common dots on images"""
-        for idx, (image, pts) in enumerate(
-            zip(self._images_array, self._dot_image_points_xy)
-        ):
-            fig = plt.figure(f'image_{idx:d}_annotated_dots')
-            plt.imshow(image, cmap='gray')
-            plt.scatter(*pts.data, marker='.', color='red')
+        for idx_image in range(self._num_images):
+            fig = plt.figure(f'image_{idx_image:d}_annotated_dots')
+            plt.imshow(self._images[idx_image].image, cmap='gray')
+            plt.scatter(*self._dot_image_points_xy[idx_image].data, marker='.', color='red')
             self.figures.append(fig)
 
     def _plot_marker_corners(self) -> None:
         """Plots images with annotated marker corners"""
-        for idx_cam, image in enumerate(self._images_array):
-            fig = plt.figure(f'image_{idx_cam:d}_annotated_marker_corners')
+        for idx_image in range(self._num_images):
+            fig = plt.figure(f'image_{idx_image:d}_annotated_marker_corners')
             ax = fig.gca()
-            ax.imshow(image, cmap='gray')
-            Vxy(self._images[idx_cam].pts_im_xy.T).draw(ax=ax)
+            ax.imshow(self._images[idx_image].image, cmap='gray')
+            Vxy(self._images[idx_image].pts_im_xy.T).draw(ax=ax)
             self.figures.append(fig)
 
     def _plot_located_cameras_and_points(self) -> None:
@@ -328,7 +325,9 @@ class FixedPatternSetupCalibrate:
     def save_figures(self, dir_save: str) -> None:
         """Saves figures in given directory"""
         for fig in self.figures:
-            fig.savefig(os.path.join(dir_save, fig.get_label() + '.png'))
+            file = os.path.join(dir_save, fig.get_label() + '.png')
+            lt.info(f'Saving figure to file: {file:s}')
+            fig.savefig(file)
 
     def run(self) -> None:
         """Runs full calibration sequence"""

--- a/opencsp/app/fixed_pattern_deflectometry/test/test_FixedPatternDotLocations.py
+++ b/opencsp/app/fixed_pattern_deflectometry/test/test_FixedPatternDotLocations.py
@@ -66,7 +66,7 @@ def test_FixedPatternDotLocations():
 def test_from_Display():
     # Load display
     file_disp = os.path.join(
-        opencsp_code_dir,
+        opencsp_code_dir(),
         'test/data/sofast_measurements/display_distorted_3d.h5',
     )
     display = Display.load_from_hdf(file_disp)

--- a/opencsp/app/fixed_pattern_deflectometry/test/test_FixedPatternDotLocations.py
+++ b/opencsp/app/fixed_pattern_deflectometry/test/test_FixedPatternDotLocations.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternDotLocations import (
     FixedPatternDotLocations,
 )
@@ -66,7 +66,7 @@ def test_FixedPatternDotLocations():
 def test_from_Display():
     # Load display
     file_disp = os.path.join(
-        os.path.dirname(opencsp.__file__),
+        opencsp_code_dir,
         'test/data/sofast_measurements/display_distorted_3d.h5',
     )
     display = Display.load_from_hdf(file_disp)

--- a/opencsp/app/fixed_pattern_deflectometry/test/test_FixedPatternSetupCalibrate.py
+++ b/opencsp/app/fixed_pattern_deflectometry/test/test_FixedPatternSetupCalibrate.py
@@ -1,0 +1,85 @@
+"""Example script that performs dot location calibration using photogrammetry.
+
+"""
+import os
+from os.path import join, dirname, exists
+
+import numpy as np
+
+from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternDotLocations import \
+    FixedPatternDotLocations
+from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternSetupCalibrate import \
+    FixedPatternSetupCalibrate
+from opencsp.common.lib.camera.Camera import Camera
+from opencsp.common.lib.geometry.Vxy import Vxy
+from opencsp.common.lib.geometry.Vxyz import Vxyz
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
+from opencsp.common.lib.photogrammetry import photogrammetry as ph
+
+
+def test_FixedPatternSetupCalibrate():
+    """Tests dot-location calibration
+    """
+    # Define dot location images and origins
+    base_dir = join(
+        opencsp_code_dir(),
+        'test',
+        'data',
+        'fixed_pattern_deflectometry_measurements',
+        'dot_location_calibration',
+    )
+    files = [
+        join(base_dir, 'measurements/images/DSC03965.JPG'),
+        join(base_dir, 'measurements/images/DSC03967.JPG'),
+        join(base_dir, 'measurements/images/DSC03970.JPG'),
+        join(base_dir, 'measurements/images/DSC03972.JPG'),
+    ]
+    origins = Vxy(([4950, 4610, 4221, 3617], [3359, 3454, 3467, 3553]))
+
+    # Define other files
+    file_camera_marker = join(base_dir, 'measurements/camera_calibration.h5')
+    file_xyz_points = join(base_dir, 'measurements/point_locations.csv')
+    file_fpd_dot_locs_exp = join(base_dir, 'calculations/fixed_pattern_dot_locations.h5')
+    dir_save = join(dirname(__file__), 'data/output/dot_location_calibration')
+
+    if not exists(dir_save):
+        os.makedirs(dir_save)
+
+    # Load images
+    images = []
+    for file in files:
+        images.append(ph.load_image_grayscale(file))
+
+    # Load marker corner locations
+    data = np.loadtxt(file_xyz_points, delimiter=',')
+    pts_xyz_corners = Vxyz(data[:, 2:5].T)
+    ids_corners = data[:, 1]
+
+    # Load expedted FPD dot locations
+    dot_locs_exp = FixedPatternDotLocations.load_from_hdf(file_fpd_dot_locs_exp)
+
+    # Load cameras
+    camera_marker = Camera.load_from_hdf(file_camera_marker)
+
+    # Perform dot location calibration
+    cal_dot_locs = FixedPatternSetupCalibrate(
+        images, origins, camera_marker, pts_xyz_corners, ids_corners, -32, 31, -31, 32
+    )
+    cal_dot_locs.run()
+
+    # Save data
+    dot_locs = cal_dot_locs.get_dot_location_object()
+    dot_locs.save_to_hdf(join(dir_save, 'fixed_pattern_dot_locations.h5'))
+
+    # Save figures
+    for fig in cal_dot_locs.figures:
+        fig.savefig(join(dir_save, fig.get_label() + '.png'))
+
+    # Test
+    np.testing.assert_allclose(dot_locs.xyz_dot_loc, dot_locs_exp.xyz_dot_loc)
+    np.testing.assert_allclose(dot_locs.x_dot_index, dot_locs_exp.x_dot_index)
+    np.testing.assert_allclose(dot_locs.y_dot_index, dot_locs_exp.y_dot_index)
+
+
+if __name__ == '__main__':
+    test_FixedPatternSetupCalibrate()

--- a/opencsp/app/fixed_pattern_deflectometry/test/test_FixedPatternSetupCalibrate.py
+++ b/opencsp/app/fixed_pattern_deflectometry/test/test_FixedPatternSetupCalibrate.py
@@ -14,7 +14,7 @@ from opencsp.common.lib.camera.Camera import Camera
 from opencsp.common.lib.geometry.Vxy import Vxy
 from opencsp.common.lib.geometry.Vxyz import Vxyz
 from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
-from opencsp.common.lib.photogrammetry import photogrammetry as ph
+import opencsp.common.lib.tool.log_tools as lt
 
 
 def test_FixedPatternSetupCalibrate():
@@ -45,10 +45,8 @@ def test_FixedPatternSetupCalibrate():
     if not exists(dir_save):
         os.makedirs(dir_save)
 
-    # Load images
-    images = []
-    for file in files:
-        images.append(ph.load_image_grayscale(file))
+    # Set up logger
+    lt.logger(log_dir_body_ext=join(dir_save, 'log.txt'), level=lt.log.INFO)
 
     # Load marker corner locations
     data = np.loadtxt(file_xyz_points, delimiter=',')
@@ -63,17 +61,15 @@ def test_FixedPatternSetupCalibrate():
 
     # Perform dot location calibration
     cal_dot_locs = FixedPatternSetupCalibrate(
-        images, origins, camera_marker, pts_xyz_corners, ids_corners, -32, 31, -31, 32
+        files, origins, camera_marker, pts_xyz_corners, ids_corners, -32, 31, -31, 32
     )
+    cal_dot_locs.plot = True
     cal_dot_locs.run()
 
     # Save data
     dot_locs = cal_dot_locs.get_dot_location_object()
     dot_locs.save_to_hdf(join(dir_save, 'fixed_pattern_dot_locations.h5'))
-
-    # Save figures
-    for fig in cal_dot_locs.figures:
-        fig.savefig(join(dir_save, fig.get_label() + '.png'))
+    cal_dot_locs.save_figures(dir_save)
 
     # Test
     np.testing.assert_allclose(dot_locs.xyz_dot_loc, dot_locs_exp.xyz_dot_loc)

--- a/opencsp/app/fixed_pattern_deflectometry/test/test_project_fixed_pattern_target.py
+++ b/opencsp/app/fixed_pattern_deflectometry/test/test_project_fixed_pattern_target.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.fixed_pattern_deflectometry.lib.FixedPatternScreenProjection import (
     FixedPatternScreenProjection,
 )
@@ -15,7 +15,7 @@ from opencsp.common.lib.deflectometry.ImageProjection import ImageProjection
 def test_project_fixed_pattern_target():
     # Set pattern parameters
     file_image_projection = os.path.join(
-        os.path.dirname(opencsp.__file__),
+        opencsp_code_dir,
         "test/data/sofast_measurements/general/Image_Projection_test.h5",
     )
 

--- a/opencsp/app/fixed_pattern_deflectometry/test/test_project_fixed_pattern_target.py
+++ b/opencsp/app/fixed_pattern_deflectometry/test/test_project_fixed_pattern_target.py
@@ -15,7 +15,7 @@ from opencsp.common.lib.deflectometry.ImageProjection import ImageProjection
 def test_project_fixed_pattern_target():
     # Set pattern parameters
     file_image_projection = os.path.join(
-        opencsp_code_dir,
+        opencsp_code_dir(),
         "test/data/sofast_measurements/general/Image_Projection_test.h5",
     )
 

--- a/opencsp/app/scene_reconstruction/test/generate_downsampled_dataset.py
+++ b/opencsp/app/scene_reconstruction/test/generate_downsampled_dataset.py
@@ -66,7 +66,7 @@ def downsample_dataset(dir_input: str, dir_output: str) -> None:
 if __name__ == '__main__':
     downsample_dataset(
         dir_input=join(
-            opencsp_code_dir,
+            opencsp_code_dir(),
             '../../sample_data/scene_reconstruction/data_measurement',
         ),
         dir_output=join(os.path.dirname(__file__), 'data/data_measurement'),

--- a/opencsp/app/scene_reconstruction/test/generate_downsampled_dataset.py
+++ b/opencsp/app/scene_reconstruction/test/generate_downsampled_dataset.py
@@ -12,7 +12,7 @@ import shutil
 import imageio.v3 as imageio
 from tqdm import tqdm
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 import opencsp.common.lib.test.downsample_data as dd
 
 
@@ -58,14 +58,15 @@ def downsample_dataset(dir_input: str, dir_output: str) -> None:
 
     # Downsample aruco marker camera
     print('Downsampling camera...')
-    camera_aruco_ds = dd.downsample_camera(join(dir_input, 'camera.h5'), n_aruco)
+    camera_aruco_ds = dd.downsample_camera(
+        join(dir_input, 'camera.h5'), n_aruco)
     camera_aruco_ds.save_to_hdf(join(dir_output, 'camera.h5'))
 
 
 if __name__ == '__main__':
     downsample_dataset(
         dir_input=join(
-            os.path.dirname(opencsp.__file__),
+            opencsp_code_dir,
             '../../sample_data/scene_reconstruction/data_measurement',
         ),
         dir_output=join(os.path.dirname(__file__), 'data/data_measurement'),

--- a/opencsp/app/sofast/calibration/test/generate_downsampled_dataset.py
+++ b/opencsp/app/sofast/calibration/test/generate_downsampled_dataset.py
@@ -7,8 +7,8 @@ from os.path import join
 import shutil
 
 from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
-import opencsp.app.sofast.test.downsample_sofast_data as ds
 import opencsp.common.lib.test.downsample_data as dd
+import opencsp.test.data.sofast_measurements.downsample_sofast_data as ds
 
 
 def downsample_dataset(dir_input: str, dir_output: str) -> None:
@@ -48,8 +48,7 @@ def downsample_dataset(dir_input: str, dir_output: str) -> None:
         join(dir_input, 'screen_shape_sofast_measurements/pose_4.h5'),
     ]
     for file_meas in files_meas:
-        print(
-            f'Downsampling sofast measurement: {os.path.basename(file_meas):s}...')
+        print(f'Downsampling sofast measurement: {os.path.basename(file_meas):s}...')
         meas_ds = ds.downsample_measurement(file_meas, n_sofast)
         meas_ds.save_to_hdf(
             join(dir_output_screen_measurements, os.path.basename(file_meas))

--- a/opencsp/app/sofast/calibration/test/generate_downsampled_dataset.py
+++ b/opencsp/app/sofast/calibration/test/generate_downsampled_dataset.py
@@ -6,7 +6,7 @@ import os
 from os.path import join
 import shutil
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 import opencsp.app.sofast.test.downsample_sofast_data as ds
 import opencsp.common.lib.test.downsample_data as dd
 
@@ -48,7 +48,8 @@ def downsample_dataset(dir_input: str, dir_output: str) -> None:
         join(dir_input, 'screen_shape_sofast_measurements/pose_4.h5'),
     ]
     for file_meas in files_meas:
-        print(f'Downsampling sofast measurement: {os.path.basename(file_meas):s}...')
+        print(
+            f'Downsampling sofast measurement: {os.path.basename(file_meas):s}...')
         meas_ds = ds.downsample_measurement(file_meas, n_sofast)
         meas_ds.save_to_hdf(
             join(dir_output_screen_measurements, os.path.basename(file_meas))
@@ -65,7 +66,7 @@ def downsample_dataset(dir_input: str, dir_output: str) -> None:
 if __name__ == '__main__':
     downsample_dataset(
         dir_input=join(
-            os.path.dirname(opencsp.__file__),
+            opencsp_code_dir,
             '../../sample_data/sofast/data_photogrammetric_calibration/data_measurement',
         ),
         dir_output=join(os.path.dirname(__file__), 'data/data_measurement'),

--- a/opencsp/app/sofast/calibration/test/generate_downsampled_dataset.py
+++ b/opencsp/app/sofast/calibration/test/generate_downsampled_dataset.py
@@ -66,7 +66,7 @@ def downsample_dataset(dir_input: str, dir_output: str) -> None:
 if __name__ == '__main__':
     downsample_dataset(
         dir_input=join(
-            opencsp_code_dir,
+            opencsp_code_dir(),
             '../../sample_data/sofast/data_photogrammetric_calibration/data_measurement',
         ),
         dir_output=join(os.path.dirname(__file__), 'data/data_measurement'),

--- a/opencsp/app/sofast/calibration/test/test_CalibrationScreenShape.py
+++ b/opencsp/app/sofast/calibration/test/test_CalibrationScreenShape.py
@@ -8,7 +8,7 @@ import pytest
 
 import numpy as np
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.calibration.lib.CalibrationScreenShape import (
     CalibrationScreenShape,
     DataInput,
@@ -50,7 +50,7 @@ class TestCalibrationScreenShape(unittest.TestCase):
         if (dir_input is None) or (dir_output is None):
             # Define default data directories
             base_dir = join(
-                os.path.dirname(opencsp.__file__), 'common/lib/deflectometry/test'
+                opencsp_code_dir, 'common/lib/deflectometry/test'
             )
             dir_input = join(base_dir, 'data/data_measurement')
             dir_output = join(base_dir, 'data/data_expected')
@@ -79,7 +79,8 @@ class TestCalibrationScreenShape(unittest.TestCase):
             file_screen_cal_point_pairs, delimiter=',', skiprows=1
         ).astype(int)
         camera = Camera.load_from_hdf(file_camera_distortion)
-        image_projection_data = ImageProjection.load_from_hdf(file_image_projection)
+        image_projection_data = ImageProjection.load_from_hdf(
+            file_image_projection)
 
         # Store input data in data class
         data_input = DataInput(
@@ -89,7 +90,8 @@ class TestCalibrationScreenShape(unittest.TestCase):
             pts_xyz_marker,
             camera,
             image_projection_data,
-            [Measurement.load_from_hdf(f) for f in files_screen_shape_measurement],
+            [Measurement.load_from_hdf(f)
+             for f in files_screen_shape_measurement],
         )
 
         # Perform screen position calibration

--- a/opencsp/app/sofast/calibration/test/test_CalibrationScreenShape.py
+++ b/opencsp/app/sofast/calibration/test/test_CalibrationScreenShape.py
@@ -1,12 +1,11 @@
 """Tests Sofast screen distortion calibration
 """
-from glob import glob
-import os
 from os.path import join
 import unittest
-import pytest
 
+from glob import glob
 import numpy as np
+import pytest
 
 from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.calibration.lib.CalibrationScreenShape import (
@@ -79,8 +78,7 @@ class TestCalibrationScreenShape(unittest.TestCase):
             file_screen_cal_point_pairs, delimiter=',', skiprows=1
         ).astype(int)
         camera = Camera.load_from_hdf(file_camera_distortion)
-        image_projection_data = ImageProjection.load_from_hdf(
-            file_image_projection)
+        image_projection_data = ImageProjection.load_from_hdf(file_image_projection)
 
         # Store input data in data class
         data_input = DataInput(
@@ -90,8 +88,7 @@ class TestCalibrationScreenShape(unittest.TestCase):
             pts_xyz_marker,
             camera,
             image_projection_data,
-            [Measurement.load_from_hdf(f)
-             for f in files_screen_shape_measurement],
+            [Measurement.load_from_hdf(f) for f in files_screen_shape_measurement],
         )
 
         # Perform screen position calibration

--- a/opencsp/app/sofast/calibration/test/test_CalibrationScreenShape.py
+++ b/opencsp/app/sofast/calibration/test/test_CalibrationScreenShape.py
@@ -50,7 +50,7 @@ class TestCalibrationScreenShape(unittest.TestCase):
         if (dir_input is None) or (dir_output is None):
             # Define default data directories
             base_dir = join(
-                opencsp_code_dir, 'common/lib/deflectometry/test'
+                opencsp_code_dir(), 'common/lib/deflectometry/test'
             )
             dir_input = join(base_dir, 'data/data_measurement')
             dir_output = join(base_dir, 'data/data_expected')

--- a/opencsp/app/sofast/calibration/test/test_save_physical_setup_file.py
+++ b/opencsp/app/sofast/calibration/test/test_save_physical_setup_file.py
@@ -1,15 +1,14 @@
-import os
 from os.path import join
 
 import numpy as np
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.calibration.lib.save_physical_setup_file import (
     save_physical_setup_file,
 )
 from opencsp.common.lib.tool.hdf5_tools import load_hdf5_datasets
 from opencsp.common.lib.geometry.Vxy import Vxy
 from opencsp.common.lib.geometry.Vxyz import Vxyz
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 import opencsp.common.lib.tool.file_tools as ft
 
 
@@ -24,8 +23,7 @@ def test_save_physical_setup_file():
     ft.create_directories_if_necessary(dir_output)
 
     # Define data files
-    file_screen_distortion_data = join(
-        dir_input, 'screen_distortion_data_100_100.h5')
+    file_screen_distortion_data = join(dir_input, 'screen_distortion_data_100_100.h5')
     file_cam = join(dir_input, 'camera_rvec_tvec.csv')
 
     # Load data
@@ -42,10 +40,9 @@ def test_save_physical_setup_file():
     tvec = data_cam[1]
 
     # Save physical setup file
-    save_physical_setup_file(screen_distortion_data,
-                             name, rvec, tvec, file_save)
-    print('Test physical setup file save successfully.')
+    save_physical_setup_file(screen_distortion_data, name, rvec, tvec, file_save)
 
 
 if __name__ == '__main__':
     test_save_physical_setup_file()
+    print('Test physical setup file save successfully.')

--- a/opencsp/app/sofast/calibration/test/test_save_physical_setup_file.py
+++ b/opencsp/app/sofast/calibration/test/test_save_physical_setup_file.py
@@ -16,7 +16,7 @@ import opencsp.common.lib.tool.file_tools as ft
 def test_save_physical_setup_file():
     """Loads data and saves test Display file"""
     # Define input file directory
-    base_dir = join(opencsp_code_dir, 'common/lib/deflectometry/test')
+    base_dir = join(opencsp_code_dir(), 'common/lib/deflectometry/test')
     dir_input = join(base_dir, 'data', 'data_expected')
     dir_output = join(base_dir, 'data', 'output')
     file_save = join(dir_output, 'test_physical_setup_file.h5')

--- a/opencsp/app/sofast/calibration/test/test_save_physical_setup_file.py
+++ b/opencsp/app/sofast/calibration/test/test_save_physical_setup_file.py
@@ -3,7 +3,7 @@ from os.path import join
 
 import numpy as np
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.calibration.lib.save_physical_setup_file import (
     save_physical_setup_file,
 )
@@ -16,7 +16,7 @@ import opencsp.common.lib.tool.file_tools as ft
 def test_save_physical_setup_file():
     """Loads data and saves test Display file"""
     # Define input file directory
-    base_dir = join(os.path.dirname(opencsp.__file__), 'common/lib/deflectometry/test')
+    base_dir = join(opencsp_code_dir, 'common/lib/deflectometry/test')
     dir_input = join(base_dir, 'data', 'data_expected')
     dir_output = join(base_dir, 'data', 'output')
     file_save = join(dir_output, 'test_physical_setup_file.h5')
@@ -24,7 +24,8 @@ def test_save_physical_setup_file():
     ft.create_directories_if_necessary(dir_output)
 
     # Define data files
-    file_screen_distortion_data = join(dir_input, 'screen_distortion_data_100_100.h5')
+    file_screen_distortion_data = join(
+        dir_input, 'screen_distortion_data_100_100.h5')
     file_cam = join(dir_input, 'camera_rvec_tvec.csv')
 
     # Load data
@@ -41,7 +42,8 @@ def test_save_physical_setup_file():
     tvec = data_cam[1]
 
     # Save physical setup file
-    save_physical_setup_file(screen_distortion_data, name, rvec, tvec, file_save)
+    save_physical_setup_file(screen_distortion_data,
+                             name, rvec, tvec, file_save)
     print('Test physical setup file save successfully.')
 
 

--- a/opencsp/app/sofast/test/test_System.py
+++ b/opencsp/app/sofast/test/test_System.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.lib.Fringes import Fringes
 from opencsp.app.sofast.lib.System import System
 from opencsp.app.sofast.test.ImageAcquisition_no_camera import ImageAcquisition
@@ -15,7 +15,7 @@ from opencsp.common.lib.deflectometry.ImageProjection import ImageProjection
 def test_System():
     # Get test data location
     base_dir = os.path.join(
-        os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements'
+        opencsp_code_dir, 'test/data/sofast_measurements'
     )
 
     # Create fringe object

--- a/opencsp/app/sofast/test/test_System.py
+++ b/opencsp/app/sofast/test/test_System.py
@@ -4,11 +4,11 @@ import os
 
 import pytest
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.lib.Fringes import Fringes
 from opencsp.app.sofast.lib.System import System
 from opencsp.app.sofast.test.ImageAcquisition_no_camera import ImageAcquisition
 from opencsp.common.lib.deflectometry.ImageProjection import ImageProjection
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 
 
 @pytest.mark.no_xvfb

--- a/opencsp/app/sofast/test/test_System.py
+++ b/opencsp/app/sofast/test/test_System.py
@@ -15,7 +15,7 @@ from opencsp.common.lib.deflectometry.ImageProjection import ImageProjection
 def test_System():
     # Get test data location
     base_dir = os.path.join(
-        opencsp_code_dir, 'test/data/sofast_measurements'
+        opencsp_code_dir(), 'test/data/sofast_measurements'
     )
 
     # Create fringe object

--- a/opencsp/app/sofast/test/test_integration_multi_facet.py
+++ b/opencsp/app/sofast/test/test_integration_multi_facet.py
@@ -32,7 +32,7 @@ class TestMulti(unittest.TestCase):
         # Get test data location
         if base_dir is None:
             base_dir = os.path.join(
-                opencsp_code_dir, 'test/data/sofast_measurements'
+                opencsp_code_dir(), 'test/data/sofast_measurements'
             )
 
         # Directory Setup

--- a/opencsp/app/sofast/test/test_integration_multi_facet.py
+++ b/opencsp/app/sofast/test/test_integration_multi_facet.py
@@ -6,16 +6,16 @@ import unittest
 from scipy.spatial.transform import Rotation
 import numpy as np
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
-from opencsp.common.lib.deflectometry.Display import Display
-from opencsp.common.lib.deflectometry.EnsembleData import EnsembleData
-from opencsp.common.lib.deflectometry.FacetData import FacetData
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
 from opencsp.app.sofast.lib.Sofast import Sofast
 from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.common.lib.camera.Camera import Camera
+from opencsp.common.lib.deflectometry.Display import Display
+from opencsp.common.lib.deflectometry.EnsembleData import EnsembleData
+from opencsp.common.lib.deflectometry.FacetData import FacetData
 from opencsp.common.lib.geometry.Vxyz import Vxyz
 from opencsp.common.lib.tool.hdf5_tools import load_hdf5_datasets
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 
 
 class TestMulti(unittest.TestCase):
@@ -36,8 +36,7 @@ class TestMulti(unittest.TestCase):
             )
 
         # Directory Setup
-        file_dataset = os.path.join(
-            base_dir, 'calculations_facet_ensemble/data.h5')
+        file_dataset = os.path.join(base_dir, 'calculations_facet_ensemble/data.h5')
         file_measurement = os.path.join(base_dir, 'measurement_ensemble.h5')
         print(f'Using dataset: {os.path.abspath(file_dataset)}')
 
@@ -101,8 +100,7 @@ class TestMulti(unittest.TestCase):
         ensemble_data = load_hdf5_datasets(datasets, file_dataset)
         ensemble_data = EnsembleData(
             Vxyz(ensemble_data['v_facet_locations']),
-            [Rotation.from_rotvec(r)
-             for r in ensemble_data['r_facet_ensemble']],
+            [Rotation.from_rotvec(r) for r in ensemble_data['r_facet_ensemble']],
             ensemble_data['ensemble_perimeter'],
             Vxyz(ensemble_data['v_centroid_ensemble']),
         )
@@ -116,8 +114,7 @@ class TestMulti(unittest.TestCase):
             ]
             data = load_hdf5_datasets(datasets, file_dataset)
             facet_data.append(
-                FacetData(Vxyz(data['v_facet_corners']),
-                          Vxyz(data['v_centroid_facet']))
+                FacetData(Vxyz(data['v_facet_corners']), Vxyz(data['v_centroid_facet']))
             )
 
         # Load surface data
@@ -134,8 +131,7 @@ class TestMulti(unittest.TestCase):
             surface_data.append(data)
 
         # Run SOFAST
-        sofast.process_optic_multifacet(
-            facet_data, ensemble_data, surface_data)
+        sofast.process_optic_multifacet(facet_data, ensemble_data, surface_data)
 
         # Store data
         cls.data_test = {'slopes_facet_xy': [], 'surf_coefs_facet': []}

--- a/opencsp/app/sofast/test/test_integration_multi_facet.py
+++ b/opencsp/app/sofast/test/test_integration_multi_facet.py
@@ -6,7 +6,7 @@ import unittest
 from scipy.spatial.transform import Rotation
 import numpy as np
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.common.lib.deflectometry.EnsembleData import EnsembleData
 from opencsp.common.lib.deflectometry.FacetData import FacetData
@@ -32,11 +32,12 @@ class TestMulti(unittest.TestCase):
         # Get test data location
         if base_dir is None:
             base_dir = os.path.join(
-                os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements'
+                opencsp_code_dir, 'test/data/sofast_measurements'
             )
 
         # Directory Setup
-        file_dataset = os.path.join(base_dir, 'calculations_facet_ensemble/data.h5')
+        file_dataset = os.path.join(
+            base_dir, 'calculations_facet_ensemble/data.h5')
         file_measurement = os.path.join(base_dir, 'measurement_ensemble.h5')
         print(f'Using dataset: {os.path.abspath(file_dataset)}')
 
@@ -100,7 +101,8 @@ class TestMulti(unittest.TestCase):
         ensemble_data = load_hdf5_datasets(datasets, file_dataset)
         ensemble_data = EnsembleData(
             Vxyz(ensemble_data['v_facet_locations']),
-            [Rotation.from_rotvec(r) for r in ensemble_data['r_facet_ensemble']],
+            [Rotation.from_rotvec(r)
+             for r in ensemble_data['r_facet_ensemble']],
             ensemble_data['ensemble_perimeter'],
             Vxyz(ensemble_data['v_centroid_ensemble']),
         )
@@ -114,7 +116,8 @@ class TestMulti(unittest.TestCase):
             ]
             data = load_hdf5_datasets(datasets, file_dataset)
             facet_data.append(
-                FacetData(Vxyz(data['v_facet_corners']), Vxyz(data['v_centroid_facet']))
+                FacetData(Vxyz(data['v_facet_corners']),
+                          Vxyz(data['v_centroid_facet']))
             )
 
         # Load surface data
@@ -131,7 +134,8 @@ class TestMulti(unittest.TestCase):
             surface_data.append(data)
 
         # Run SOFAST
-        sofast.process_optic_multifacet(facet_data, ensemble_data, surface_data)
+        sofast.process_optic_multifacet(
+            facet_data, ensemble_data, surface_data)
 
         # Store data
         cls.data_test = {'slopes_facet_xy': [], 'surf_coefs_facet': []}

--- a/opencsp/app/sofast/test/test_integration_single_facet.py
+++ b/opencsp/app/sofast/test/test_integration_single_facet.py
@@ -6,7 +6,7 @@ import unittest
 
 import numpy as np
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.common.lib.deflectometry.FacetData import FacetData
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
@@ -31,7 +31,7 @@ class TestSingle(unittest.TestCase):
         # Get test data location
         if base_dir is None:
             base_dir = os.path.join(
-                os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements'
+                opencsp_code_dir, 'test/data/sofast_measurements'
             )
 
         # Find all test files
@@ -148,7 +148,8 @@ class TestSingle(unittest.TestCase):
             sofast.process_optic_singlefacet(facet_data, surface_data)
 
             # Store test data
-            cls.slopes.append(sofast.data_characterization_facet[0].slopes_facet_xy)
+            cls.slopes.append(
+                sofast.data_characterization_facet[0].slopes_facet_xy)
             cls.surf_coefs.append(
                 sofast.data_characterization_facet[0].surf_coefs_facet
             )

--- a/opencsp/app/sofast/test/test_integration_single_facet.py
+++ b/opencsp/app/sofast/test/test_integration_single_facet.py
@@ -31,7 +31,7 @@ class TestSingle(unittest.TestCase):
         # Get test data location
         if base_dir is None:
             base_dir = os.path.join(
-                opencsp_code_dir, 'test/data/sofast_measurements'
+                opencsp_code_dir(), 'test/data/sofast_measurements'
             )
 
         # Find all test files

--- a/opencsp/app/sofast/test/test_integration_single_facet.py
+++ b/opencsp/app/sofast/test/test_integration_single_facet.py
@@ -6,14 +6,14 @@ import unittest
 
 import numpy as np
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
-from opencsp.common.lib.deflectometry.Display import Display
-from opencsp.common.lib.deflectometry.FacetData import FacetData
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
 from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.app.sofast.lib.Sofast import Sofast
 from opencsp.common.lib.camera.Camera import Camera
+from opencsp.common.lib.deflectometry.Display import Display
+from opencsp.common.lib.deflectometry.FacetData import FacetData
 from opencsp.common.lib.geometry.Vxyz import Vxyz
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.tool.hdf5_tools import load_hdf5_datasets
 
 
@@ -148,8 +148,7 @@ class TestSingle(unittest.TestCase):
             sofast.process_optic_singlefacet(facet_data, surface_data)
 
             # Store test data
-            cls.slopes.append(
-                sofast.data_characterization_facet[0].slopes_facet_xy)
+            cls.slopes.append(sofast.data_characterization_facet[0].slopes_facet_xy)
             cls.surf_coefs.append(
                 sofast.data_characterization_facet[0].surf_coefs_facet
             )

--- a/opencsp/app/sofast/test/test_integration_undefined.py
+++ b/opencsp/app/sofast/test/test_integration_undefined.py
@@ -16,7 +16,7 @@ from opencsp.common.lib.tool.hdf5_tools import load_hdf5_datasets
 def test_undefined():
     # Get test data location
     base_dir = os.path.join(
-        opencsp_code_dir, 'test/data/sofast_measurements'
+        opencsp_code_dir(), 'test/data/sofast_measurements'
     )
 
     # Directory Setup

--- a/opencsp/app/sofast/test/test_integration_undefined.py
+++ b/opencsp/app/sofast/test/test_integration_undefined.py
@@ -4,7 +4,7 @@ import os
 
 import numpy as np
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
 from opencsp.app.sofast.lib.Measurement import Measurement
@@ -16,11 +16,12 @@ from opencsp.common.lib.tool.hdf5_tools import load_hdf5_datasets
 def test_undefined():
     # Get test data location
     base_dir = os.path.join(
-        os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements'
+        opencsp_code_dir, 'test/data/sofast_measurements'
     )
 
     # Directory Setup
-    file_dataset = os.path.join(base_dir, 'calculations_undefined_mirror/data.h5')
+    file_dataset = os.path.join(
+        base_dir, 'calculations_undefined_mirror/data.h5')
     file_measurement = os.path.join(base_dir, 'measurement_facet.h5')
 
     # Load data
@@ -105,7 +106,8 @@ def test_undefined():
     slopes = sofast.data_characterization_facet[0].slopes_facet_xy
     slope_coefs = sofast.data_characterization_facet[0].slope_coefs_facet
 
-    np.testing.assert_allclose(data['slopes_facet_xy'], slopes, atol=1e-7, rtol=0)
+    np.testing.assert_allclose(
+        data['slopes_facet_xy'], slopes, atol=1e-7, rtol=0)
     np.testing.assert_allclose(
         data['slope_coefs_facet'], slope_coefs, atol=1e-8, rtol=0
     )

--- a/opencsp/app/sofast/test/test_integration_undefined.py
+++ b/opencsp/app/sofast/test/test_integration_undefined.py
@@ -4,12 +4,12 @@ import os
 
 import numpy as np
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
-from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
 from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.app.sofast.lib.Sofast import Sofast
 from opencsp.common.lib.camera.Camera import Camera
+from opencsp.common.lib.deflectometry.Display import Display
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.tool.hdf5_tools import load_hdf5_datasets
 
 
@@ -20,8 +20,7 @@ def test_undefined():
     )
 
     # Directory Setup
-    file_dataset = os.path.join(
-        base_dir, 'calculations_undefined_mirror/data.h5')
+    file_dataset = os.path.join(base_dir, 'calculations_undefined_mirror/data.h5')
     file_measurement = os.path.join(base_dir, 'measurement_facet.h5')
 
     # Load data
@@ -106,8 +105,7 @@ def test_undefined():
     slopes = sofast.data_characterization_facet[0].slopes_facet_xy
     slope_coefs = sofast.data_characterization_facet[0].slope_coefs_facet
 
-    np.testing.assert_allclose(
-        data['slopes_facet_xy'], slopes, atol=1e-7, rtol=0)
+    np.testing.assert_allclose(data['slopes_facet_xy'], slopes, atol=1e-7, rtol=0)
     np.testing.assert_allclose(
         data['slope_coefs_facet'], slope_coefs, atol=1e-8, rtol=0
     )

--- a/opencsp/common/lib/deflectometry/BlobIndex.py
+++ b/opencsp/common/lib/deflectometry/BlobIndex.py
@@ -110,7 +110,8 @@ class BlobIndex:
         dists_perp = np.abs(v_perp.dot(points_rel))  # Distance of points from line
         # Make mask of valid points
         mask = np.logical_and(
-            dists_axis > 0, dists_axis / dists_perp > self.search_perp_axis_ratio
+            dists_axis > 0,
+            dists_perp / dists_axis <= self.search_perp_axis_ratio
         )
         # Check there are points to find
         if mask.sum() == 0:

--- a/opencsp/common/lib/deflectometry/CalibrationCameraPosition.py
+++ b/opencsp/common/lib/deflectometry/CalibrationCameraPosition.py
@@ -83,8 +83,7 @@ class CalibrationCameraPosition:
 
     def find_markers(self) -> None:
         """Finds marker corner locations in image"""
-        self.ids_marker, self.pts_xy_marker_corners_list = find_aruco_marker(
-            self.image)
+        self.ids_marker, self.pts_xy_marker_corners_list = find_aruco_marker(self.image)
 
     def collect_corner_xyz_locations(self) -> None:
         """Collects corner locations of viewed markers"""
@@ -97,7 +96,7 @@ class CalibrationCameraPosition:
             # Extract calibrated corner locations (4 corners per marker)
             self.pts_xyz_active_corner_locations = (
                 self.pts_xyz_active_corner_locations.concatenate(
-                    self.pts_xyz_corners[index: index + 4]
+                    self.pts_xyz_corners[index:index + 4]
                 )
             )
 
@@ -185,8 +184,7 @@ class CalibrationCameraPosition:
         ax.imshow(self.image, cmap='gray')
         for id_, pts in zip(self.ids_marker, self.pts_xy_marker_corners_list):
             plt.scatter(*pts.T, marker='+')
-            plt.text(*pts.mean(0).T +
-                     np.array([60, 0]), id_, backgroundcolor='white')
+            plt.text(*pts.mean(0).T + np.array([60, 0]), id_, backgroundcolor='white')
 
     def plot_reprojection_error(self) -> None:
         """Plots reprojection error"""

--- a/opencsp/common/lib/deflectometry/CalibrationCameraPosition.py
+++ b/opencsp/common/lib/deflectometry/CalibrationCameraPosition.py
@@ -21,6 +21,13 @@ class CalibrationCameraPosition:
     ----------
         - rvec : rotation vector, screen to camera rotation vector
         - tvec : translation vector, camera to screen (in screen coordinates) translation vector
+
+    Verbose Settings (self.verbose)
+    -------------------------------
+        - 0 no output
+        - 1 print only output
+        - 2 print and plot output
+        - 3 plot only output
     """
 
     def __init__(
@@ -42,7 +49,6 @@ class CalibrationCameraPosition:
             Corner IDs corresponding to pts_xyz_corners
         cal_image : ndarray
             Calibration image captured by camera
-
         """
         # Initialize attributes data types
         self.camera = camera
@@ -62,11 +68,23 @@ class CalibrationCameraPosition:
         self.pts_xy_marker_corners_reprojected: Vxy
 
         # Save figures
+        self.verbose: int = 0
         self.figures: list[plt.Figure] = []
+
+    @property
+    def _to_print(self) -> bool:
+        """If verbose printing is turned on"""
+        return self.verbose in [1, 2]
+
+    @property
+    def _to_plot(self) -> bool:
+        """If verbose plotting is turned on"""
+        return self.verbose in [2, 3]
 
     def find_markers(self) -> None:
         """Finds marker corner locations in image"""
-        self.ids_marker, self.pts_xy_marker_corners_list = find_aruco_marker(self.image)
+        self.ids_marker, self.pts_xy_marker_corners_list = find_aruco_marker(
+            self.image)
 
     def collect_corner_xyz_locations(self) -> None:
         """Collects corner locations of viewed markers"""
@@ -79,11 +97,11 @@ class CalibrationCameraPosition:
             # Extract calibrated corner locations (4 corners per marker)
             self.pts_xyz_active_corner_locations = (
                 self.pts_xyz_active_corner_locations.concatenate(
-                    self.pts_xyz_corners[index : index + 4]
+                    self.pts_xyz_corners[index: index + 4]
                 )
             )
 
-    def calculate_camera_pose(self, verbose: bool = False) -> None:
+    def calculate_camera_pose(self) -> None:
         """Calculates the camera pose"""
         # Concatenate image points
         pts_img = np.vstack(self.pts_xy_marker_corners_list)
@@ -107,7 +125,7 @@ class CalibrationCameraPosition:
             self.rot_screen_cam.inv()
         )
 
-        if verbose:
+        if self._to_print:
             print('Camera pose calculated:')
             print(f'   rvec: {self.rot_screen_cam.as_rotvec()}')
             print(f'   tvec: {self.v_cam_screen_screen.data.squeeze()}')
@@ -134,7 +152,7 @@ class CalibrationCameraPosition:
 
         print(f'Saved camera rvec and tvec to: {os.path.abspath(file):s}')
 
-    def calculate_reprojection_error(self, verbose: bool = False) -> None:
+    def calculate_reprojection_error(self) -> None:
         """Calculates reprojection error"""
         # Project points
         self.pts_xy_marker_corners_reprojected = self.camera.project(
@@ -148,7 +166,7 @@ class CalibrationCameraPosition:
             np.vstack(self.pts_xy_marker_corners_list).T
         )
 
-        if verbose:
+        if self._to_print:
             errors_mag: ndarray = np.sqrt(
                 (self.errors_reprojection_xy.data.T**2).sum(axis=1)
             )
@@ -167,7 +185,8 @@ class CalibrationCameraPosition:
         ax.imshow(self.image, cmap='gray')
         for id_, pts in zip(self.ids_marker, self.pts_xy_marker_corners_list):
             plt.scatter(*pts.T, marker='+')
-            plt.text(*pts.mean(0).T + np.array([60, 0]), id_, backgroundcolor='white')
+            plt.text(*pts.mean(0).T +
+                     np.array([60, 0]), id_, backgroundcolor='white')
 
     def plot_reprojection_error(self) -> None:
         """Plots reprojection error"""
@@ -199,27 +218,16 @@ class CalibrationCameraPosition:
         ax.legend()
         ax.axis('off')
 
-    def run_calibration(self, verbose: int = 0) -> None:
-        """Runs calibration sequence
-
-        Parameters
-        ----------
-        verbose : int, optional
-            - 0=no output
-            - 1=only print outputs
-            - 2=print outputs and show plots
-            - 3=plots only with no printing
-        """
-        to_print = verbose in [1, 2]
-        to_plot = verbose in [2, 3]
+    def run_calibration(self) -> None:
+        """Runs calibration sequence"""
 
         # Run calibration
         self.find_markers()
         self.collect_corner_xyz_locations()
-        self.calculate_camera_pose(to_print)
-        self.calculate_reprojection_error(to_print)
+        self.calculate_camera_pose()
+        self.calculate_reprojection_error()
 
         # Plot figures
-        if to_plot:
+        if self._to_plot:
             self.plot_found_corners()
             self.plot_reprojection_error()

--- a/opencsp/common/lib/deflectometry/SlopeSolverData.py
+++ b/opencsp/common/lib/deflectometry/SlopeSolverData.py
@@ -1,4 +1,5 @@
 """Data class for holding output of a SlopeSolver calculation"""
+from dataclasses import dataclass
 
 from numpy import ndarray
 
@@ -7,15 +8,15 @@ from opencsp.common.lib.geometry.Vxyz import Vxyz
 import opencsp.common.lib.tool.hdf5_tools as hdf5_tools
 
 
+@dataclass
 class SlopeSolverData:
     """Contains output data of a SlopeSolver calculation"""
 
-    def __init__(self):
-        self.surf_coefs_facet: ndarray
-        self.slope_coefs_facet: ndarray
-        self.trans_alignment: TransformXYZ
-        self.v_surf_points_facet: Vxyz
-        self.slopes_facet_xy: ndarray
+    surf_coefs_facet: ndarray = None
+    slope_coefs_facet: ndarray = None
+    trans_alignment: TransformXYZ = None
+    v_surf_points_facet: Vxyz = None
+    slopes_facet_xy: ndarray = None
 
     def save_to_hdf(self, file: str, prefix: str = ''):
         """Saves data to given HDF5 file. Data is stored in PREFIX + SlopeSolverData/...

--- a/opencsp/common/lib/deflectometry/SpatialOrientation.py
+++ b/opencsp/common/lib/deflectometry/SpatialOrientation.py
@@ -133,8 +133,7 @@ class SpatialOrientation:
         self.r_screen_optic = self.r_optic_screen.inv()
 
         self.v_optic_screen_optic = (
-            self.v_optic_cam_optic +
-            self.v_cam_screen_cam.rotate(self.r_cam_optic)
+            self.v_optic_cam_optic + self.v_cam_screen_cam.rotate(self.r_cam_optic)
         )
         self.v_screen_optic_optic = -self.v_optic_screen_optic
 

--- a/opencsp/common/lib/deflectometry/SpatialOrientation.py
+++ b/opencsp/common/lib/deflectometry/SpatialOrientation.py
@@ -58,6 +58,21 @@ class SpatialOrientation:
 
         self.trans_screen_cam: TransformXYZ
 
+    def __copy__(self) -> 'SpatialOrientation':
+        """Returns a copy of spatial orientation"""
+        r_cam_screen = Rotation.from_rotvec(
+            self.r_cam_screen.as_rotvec().copy())
+        v_cam_screen_cam = self.v_cam_screen_cam.copy()
+        ori = SpatialOrientation(r_cam_screen, v_cam_screen_cam)
+
+        if self.optic_oriented:
+            r_cam_optic = Rotation.from_rotve(
+                self.r_cam_optic.as_rotvec().copy())
+            v_cam_optic_cam = self.v_cam_optic_cam.copy()
+            ori.orient_optic_cam(r_cam_optic, v_cam_optic_cam)
+
+        return ori
+
     def _orient_screen_cam(
         self, r_cam_screen: Rotation, v_cam_screen_cam: Vxyz
     ) -> None:
@@ -118,7 +133,8 @@ class SpatialOrientation:
         self.r_screen_optic = self.r_optic_screen.inv()
 
         self.v_optic_screen_optic = (
-            self.v_optic_cam_optic + self.v_cam_screen_cam.rotate(self.r_cam_optic)
+            self.v_optic_cam_optic +
+            self.v_cam_screen_cam.rotate(self.r_cam_optic)
         )
         self.v_screen_optic_optic = -self.v_optic_screen_optic
 
@@ -208,18 +224,5 @@ class SpatialOrientation:
 
         ori = cls(r_cam_screen, v_cam_screen_cam)
         ori.orient_optic_cam(r_cam_optic, v_cam_optic_cam)
-
-        return ori
-
-    def copy(self) -> 'SpatialOrientation':
-        """Returns a copy of spatial orientation"""
-        r_cam_screen = Rotation.from_rotvec(self.r_cam_screen.as_rotvec().copy())
-        v_cam_screen_cam = self.v_cam_screen_cam.copy()
-        ori = SpatialOrientation(r_cam_screen, v_cam_screen_cam)
-
-        if self.optic_oriented:
-            r_cam_optic = Rotation.from_rotve(self.r_cam_optic.as_rotvec().copy())
-            v_cam_optic_cam = self.v_cam_optic_cam.copy()
-            ori.orient_optic_cam(r_cam_optic, v_cam_optic_cam)
 
         return ori

--- a/opencsp/common/lib/deflectometry/process_optics_geometry.py
+++ b/opencsp/common/lib/deflectometry/process_optics_geometry.py
@@ -366,8 +366,7 @@ def process_undefined_geometry(
     data_geometry_general.v_cam_optic_cam_exp = v_cam_optic_cam
 
     # Find orientation of optic
-    r_cam_optic = sp.r_from_position(
-        v_cam_optic_cam, orientation.v_cam_screen_cam)
+    r_cam_optic = sp.r_from_position(v_cam_optic_cam, orientation.v_cam_screen_cam)
     data_geometry_general.r_optic_cam_exp = r_cam_optic.inv()
 
     # Orient optic
@@ -377,8 +376,7 @@ def process_undefined_geometry(
     spatial_orientation.orient_optic_cam(r_cam_optic, v_cam_optic_cam)
 
     # Calculate measure point pointing direction
-    u_cam_measure_point_facet = Uxyz(
-        spatial_orientation.v_cam_optic_optic.data)
+    u_cam_measure_point_facet = Uxyz(spatial_orientation.v_cam_optic_optic.data)
 
     # Save processed optic data
     data_geometry_facet.u_cam_measure_point_facet = u_cam_measure_point_facet
@@ -472,8 +470,7 @@ def process_multifacet_geometry(
                 )
             ).data
         )
-    v_ensemble_corns_ensemble = Vxyz(
-        np.concatenate(v_ensemble_corns_ensemble, axis=1))
+    v_ensemble_corns_ensemble = Vxyz(np.concatenate(v_ensemble_corns_ensemble, axis=1))
 
     # Concatenate all facet corners
     v_ensemble_facet_corns_all = Vxyz(
@@ -557,8 +554,7 @@ def process_multifacet_geometry(
     data_geometry_general.v_cam_optic_cam_refine_1 = v_cam_ensemble_cam_refine_1
 
     # Calculate refined measure point vector in optic coordinates
-    v_meas_pt_ensemble_cam_refine_1 = v_meas_pt_ensemble.rotate(
-        r_ensemble_cam_refine_1)
+    v_meas_pt_ensemble_cam_refine_1 = v_meas_pt_ensemble.rotate(r_ensemble_cam_refine_1)
 
     # Calculate expected location of all facet corners and centroids
     v_facet_corners_image_exp = [
@@ -634,8 +630,7 @@ def process_multifacet_geometry(
     data_geometry_general.v_cam_optic_cam_refine_2 = v_cam_ensemble_cam_refine_2
 
     # Calculate refined measure point location in optic coordinates vector
-    v_meas_pt_ensemble_cam_refine_2 = v_meas_pt_ensemble.rotate(
-        r_ensemble_cam_refine_2)
+    v_meas_pt_ensemble_cam_refine_2 = v_meas_pt_ensemble.rotate(r_ensemble_cam_refine_2)
 
     # Refine T with measured distance
     v_cam_ensemble_cam_refine_3 = sp.refine_v_distance(
@@ -712,12 +707,10 @@ def process_multifacet_geometry(
         facet_ori.orient_optic_cam(r_cam_facet, v_cam_facet_cam)
 
         # Calculate facet measure point pointing direction (measure point defined as facet centroid)
-        v_cam_meas_pt_facet = facet_ori.v_cam_optic_optic + \
-            v_facet_centroid_facet[idx]
+        v_cam_meas_pt_facet = facet_ori.v_cam_optic_optic + v_facet_centroid_facet[idx]
 
         # Calculate facet measure point to screen distance
-        v_cam_screen_optic = facet_ori.v_cam_screen_cam.rotate(
-            facet_ori.r_cam_optic)
+        v_cam_screen_optic = facet_ori.v_cam_screen_cam.rotate(facet_ori.r_cam_optic)
         dist = (v_cam_meas_pt_facet - v_cam_screen_optic).magnitude()[0]
 
         data_geometry_facet[idx].u_cam_measure_point_facet = Uxyz(

--- a/opencsp/common/lib/deflectometry/process_optics_geometry.py
+++ b/opencsp/common/lib/deflectometry/process_optics_geometry.py
@@ -1,4 +1,6 @@
 """Library of functions used to process the geometry of a deflectometry setup."""
+from copy import copy
+
 import matplotlib.pyplot as plt
 import numpy as np
 from numpy import ndarray
@@ -77,7 +79,7 @@ def process_singlefacet_geometry(
     data_error = cdc.CalculationError()
 
     # Make copy of orientation
-    ori = orientation.copy()
+    ori = copy(orientation)
 
     # Get optic data
     v_facet_corners: Vxyz = (
@@ -364,7 +366,8 @@ def process_undefined_geometry(
     data_geometry_general.v_cam_optic_cam_exp = v_cam_optic_cam
 
     # Find orientation of optic
-    r_cam_optic = sp.r_from_position(v_cam_optic_cam, orientation.v_cam_screen_cam)
+    r_cam_optic = sp.r_from_position(
+        v_cam_optic_cam, orientation.v_cam_screen_cam)
     data_geometry_general.r_optic_cam_exp = r_cam_optic.inv()
 
     # Orient optic
@@ -374,7 +377,8 @@ def process_undefined_geometry(
     spatial_orientation.orient_optic_cam(r_cam_optic, v_cam_optic_cam)
 
     # Calculate measure point pointing direction
-    u_cam_measure_point_facet = Uxyz(spatial_orientation.v_cam_optic_optic.data)
+    u_cam_measure_point_facet = Uxyz(
+        spatial_orientation.v_cam_optic_optic.data)
 
     # Save processed optic data
     data_geometry_facet.u_cam_measure_point_facet = u_cam_measure_point_facet
@@ -468,7 +472,8 @@ def process_multifacet_geometry(
                 )
             ).data
         )
-    v_ensemble_corns_ensemble = Vxyz(np.concatenate(v_ensemble_corns_ensemble, axis=1))
+    v_ensemble_corns_ensemble = Vxyz(
+        np.concatenate(v_ensemble_corns_ensemble, axis=1))
 
     # Concatenate all facet corners
     v_ensemble_facet_corns_all = Vxyz(
@@ -552,7 +557,8 @@ def process_multifacet_geometry(
     data_geometry_general.v_cam_optic_cam_refine_1 = v_cam_ensemble_cam_refine_1
 
     # Calculate refined measure point vector in optic coordinates
-    v_meas_pt_ensemble_cam_refine_1 = v_meas_pt_ensemble.rotate(r_ensemble_cam_refine_1)
+    v_meas_pt_ensemble_cam_refine_1 = v_meas_pt_ensemble.rotate(
+        r_ensemble_cam_refine_1)
 
     # Calculate expected location of all facet corners and centroids
     v_facet_corners_image_exp = [
@@ -628,7 +634,8 @@ def process_multifacet_geometry(
     data_geometry_general.v_cam_optic_cam_refine_2 = v_cam_ensemble_cam_refine_2
 
     # Calculate refined measure point location in optic coordinates vector
-    v_meas_pt_ensemble_cam_refine_2 = v_meas_pt_ensemble.rotate(r_ensemble_cam_refine_2)
+    v_meas_pt_ensemble_cam_refine_2 = v_meas_pt_ensemble.rotate(
+        r_ensemble_cam_refine_2)
 
     # Refine T with measured distance
     v_cam_ensemble_cam_refine_3 = sp.refine_v_distance(
@@ -705,10 +712,12 @@ def process_multifacet_geometry(
         facet_ori.orient_optic_cam(r_cam_facet, v_cam_facet_cam)
 
         # Calculate facet measure point pointing direction (measure point defined as facet centroid)
-        v_cam_meas_pt_facet = facet_ori.v_cam_optic_optic + v_facet_centroid_facet[idx]
+        v_cam_meas_pt_facet = facet_ori.v_cam_optic_optic + \
+            v_facet_centroid_facet[idx]
 
         # Calculate facet measure point to screen distance
-        v_cam_screen_optic = facet_ori.v_cam_screen_cam.rotate(facet_ori.r_cam_optic)
+        v_cam_screen_optic = facet_ori.v_cam_screen_cam.rotate(
+            facet_ori.r_cam_optic)
         dist = (v_cam_meas_pt_facet - v_cam_screen_optic).magnitude()[0]
 
         data_geometry_facet[idx].u_cam_measure_point_facet = Uxyz(

--- a/opencsp/common/lib/deflectometry/test/test_CalibrationCameraPosition.py
+++ b/opencsp/common/lib/deflectometry/test/test_CalibrationCameraPosition.py
@@ -79,8 +79,7 @@ class TestCalibrationCameraPosition(unittest.TestCase):
 
     def test_camera_rvec_tvec(self):
         """Tests the camera position vectors"""
-        np.testing.assert_allclose(
-            self.data_exp, self.data_meas, rtol=0, atol=1e-6)
+        np.testing.assert_allclose(self.data_exp, self.data_meas, rtol=0, atol=1e-6)
         print('rvec/tvec tested successfully.')
 
 

--- a/opencsp/common/lib/deflectometry/test/test_CalibrationCameraPosition.py
+++ b/opencsp/common/lib/deflectometry/test/test_CalibrationCameraPosition.py
@@ -65,7 +65,8 @@ class TestCalibrationCameraPosition(unittest.TestCase):
         cal_camera_position = CalibrationCameraPosition(
             camera, pts_xyz_marker, corner_ids, image
         )
-        cal_camera_position.run_calibration(verbose)
+        cal_camera_position.verbose = verbose
+        cal_camera_position.run_calibration()
 
         # Get calculated vectors
         rvec, tvec = cal_camera_position.get_data()
@@ -78,7 +79,8 @@ class TestCalibrationCameraPosition(unittest.TestCase):
 
     def test_camera_rvec_tvec(self):
         """Tests the camera position vectors"""
-        np.testing.assert_allclose(self.data_exp, self.data_meas, rtol=0, atol=1e-6)
+        np.testing.assert_allclose(
+            self.data_exp, self.data_meas, rtol=0, atol=1e-6)
         print('rvec/tvec tested successfully.')
 
 

--- a/opencsp/common/lib/deflectometry/test/test_SlopeSolver.py
+++ b/opencsp/common/lib/deflectometry/test/test_SlopeSolver.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
@@ -21,11 +21,12 @@ class TestSlopeSolver(unittest.TestCase):
     def setUpClass(cls):
         # Get test data location
         base_dir = os.path.join(
-            os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements'
+            opencsp_code_dir, 'test/data/sofast_measurements'
         )
 
         # Define test data files for single facet processing
-        cls.data_file_facet = os.path.join(base_dir, 'calculations_facet/data.h5')
+        cls.data_file_facet = os.path.join(
+            base_dir, 'calculations_facet/data.h5')
         data_file_measurement = os.path.join(base_dir, 'measurement_facet.h5')
 
         # Create spatial orientation objects
@@ -48,7 +49,8 @@ class TestSlopeSolver(unittest.TestCase):
         # Create spatial orientation object
         r_cam_optic = Rotation.from_rotvec(data['r_optic_cam_refine_1']).inv()
         v_cam_optic_cam = Vxyz(data['v_cam_optic_cam_refine_2'])
-        ori = SpatialOrientation(display.r_cam_screen, display.v_cam_screen_cam)
+        ori = SpatialOrientation(display.r_cam_screen,
+                                 display.v_cam_screen_cam)
         ori.orient_optic_cam(r_cam_optic, v_cam_optic_cam)
 
         # Perform calculations

--- a/opencsp/common/lib/deflectometry/test/test_SlopeSolver.py
+++ b/opencsp/common/lib/deflectometry/test/test_SlopeSolver.py
@@ -21,7 +21,7 @@ class TestSlopeSolver(unittest.TestCase):
     def setUpClass(cls):
         # Get test data location
         base_dir = os.path.join(
-            opencsp_code_dir, 'test/data/sofast_measurements'
+            opencsp_code_dir(), 'test/data/sofast_measurements'
         )
 
         # Define test data files for single facet processing

--- a/opencsp/common/lib/deflectometry/test/test_SlopeSolver.py
+++ b/opencsp/common/lib/deflectometry/test/test_SlopeSolver.py
@@ -6,13 +6,13 @@ import unittest
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
 from opencsp.common.lib.deflectometry.SlopeSolver import SlopeSolver
 from opencsp.common.lib.geometry.Uxyz import Uxyz
 from opencsp.common.lib.geometry.Vxyz import Vxyz
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.tool.hdf5_tools import load_hdf5_datasets
 
 
@@ -25,8 +25,7 @@ class TestSlopeSolver(unittest.TestCase):
         )
 
         # Define test data files for single facet processing
-        cls.data_file_facet = os.path.join(
-            base_dir, 'calculations_facet/data.h5')
+        cls.data_file_facet = os.path.join(base_dir, 'calculations_facet/data.h5')
         data_file_measurement = os.path.join(base_dir, 'measurement_facet.h5')
 
         # Create spatial orientation objects
@@ -49,8 +48,7 @@ class TestSlopeSolver(unittest.TestCase):
         # Create spatial orientation object
         r_cam_optic = Rotation.from_rotvec(data['r_optic_cam_refine_1']).inv()
         v_cam_optic_cam = Vxyz(data['v_cam_optic_cam_refine_2'])
-        ori = SpatialOrientation(display.r_cam_screen,
-                                 display.v_cam_screen_cam)
+        ori = SpatialOrientation(display.r_cam_screen, display.v_cam_screen_cam)
         ori.orient_optic_cam(r_cam_optic, v_cam_optic_cam)
 
         # Perform calculations

--- a/opencsp/common/lib/deflectometry/test/test_SpatialOrientation.py
+++ b/opencsp/common/lib/deflectometry/test/test_SpatialOrientation.py
@@ -18,7 +18,7 @@ class TestSpatialOrientation(unittest.TestCase):
     def setUpClass(cls):
         # Get test data location
         base_dir = os.path.join(
-            opencsp_code_dir, 'test/data/sofast_measurements'
+            opencsp_code_dir(), 'test/data/sofast_measurements'
         )
 
         # Define test data files for single facet processing

--- a/opencsp/common/lib/deflectometry/test/test_SpatialOrientation.py
+++ b/opencsp/common/lib/deflectometry/test/test_SpatialOrientation.py
@@ -6,10 +6,10 @@ import unittest
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
 from opencsp.common.lib.geometry.Vxyz import Vxyz
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.tool.hdf5_tools import load_hdf5_datasets
 
 
@@ -35,8 +35,7 @@ class TestSpatialOrientation(unittest.TestCase):
 
         r_cam_optic = Rotation.from_rotvec(data['r_optic_cam_refine_1']).inv()
         v_cam_optic_cam = Vxyz(data['v_cam_optic_cam_refine_2'])
-        ori = SpatialOrientation(display.r_cam_screen,
-                                 display.v_cam_screen_cam)
+        ori = SpatialOrientation(display.r_cam_screen, display.v_cam_screen_cam)
         ori.orient_optic_cam(r_cam_optic, v_cam_optic_cam)
 
         # Save spatial orientation
@@ -49,8 +48,7 @@ class TestSpatialOrientation(unittest.TestCase):
             + self.so.v_optic_screen_optic.rotate(self.so.r_optic_cam)
             + self.so.v_screen_cam_cam
         )
-        np.testing.assert_allclose(
-            v_exp, v_calc.data.squeeze(), rtol=0, atol=1e-10)
+        np.testing.assert_allclose(v_exp, v_calc.data.squeeze(), rtol=0, atol=1e-10)
 
     def test_translation_ring_2(self):
         v_exp = np.zeros(3)
@@ -59,17 +57,14 @@ class TestSpatialOrientation(unittest.TestCase):
             + self.so.v_screen_optic_optic.rotate(self.so.r_optic_cam)
             + self.so.v_optic_cam_cam
         )
-        np.testing.assert_allclose(
-            v_exp, v_calc.data.squeeze(), rtol=0, atol=1e-10)
+        np.testing.assert_allclose(v_exp, v_calc.data.squeeze(), rtol=0, atol=1e-10)
 
     def test_rotation_ring_1(self):
         I_exp = np.eye(3)
         I_calc = self.so.r_optic_screen * self.so.r_cam_optic * self.so.r_screen_cam
-        np.testing.assert_allclose(
-            I_exp, I_calc.as_matrix(), atol=1e-9, rtol=0)
+        np.testing.assert_allclose(I_exp, I_calc.as_matrix(), atol=1e-9, rtol=0)
 
     def test_rotation_ring_2(self):
         I_exp = np.eye(3)
         I_calc = self.so.r_cam_screen * self.so.r_optic_cam * self.so.r_screen_optic
-        np.testing.assert_allclose(
-            I_exp, I_calc.as_matrix(), atol=1e-9, rtol=0)
+        np.testing.assert_allclose(I_exp, I_calc.as_matrix(), atol=1e-9, rtol=0)

--- a/opencsp/common/lib/deflectometry/test/test_SpatialOrientation.py
+++ b/opencsp/common/lib/deflectometry/test/test_SpatialOrientation.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.common.lib.deflectometry.SpatialOrientation import SpatialOrientation
 from opencsp.common.lib.geometry.Vxyz import Vxyz
@@ -18,7 +18,7 @@ class TestSpatialOrientation(unittest.TestCase):
     def setUpClass(cls):
         # Get test data location
         base_dir = os.path.join(
-            os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements'
+            opencsp_code_dir, 'test/data/sofast_measurements'
         )
 
         # Define test data files for single facet processing
@@ -35,7 +35,8 @@ class TestSpatialOrientation(unittest.TestCase):
 
         r_cam_optic = Rotation.from_rotvec(data['r_optic_cam_refine_1']).inv()
         v_cam_optic_cam = Vxyz(data['v_cam_optic_cam_refine_2'])
-        ori = SpatialOrientation(display.r_cam_screen, display.v_cam_screen_cam)
+        ori = SpatialOrientation(display.r_cam_screen,
+                                 display.v_cam_screen_cam)
         ori.orient_optic_cam(r_cam_optic, v_cam_optic_cam)
 
         # Save spatial orientation
@@ -48,7 +49,8 @@ class TestSpatialOrientation(unittest.TestCase):
             + self.so.v_optic_screen_optic.rotate(self.so.r_optic_cam)
             + self.so.v_screen_cam_cam
         )
-        np.testing.assert_allclose(v_exp, v_calc.data.squeeze(), rtol=0, atol=1e-10)
+        np.testing.assert_allclose(
+            v_exp, v_calc.data.squeeze(), rtol=0, atol=1e-10)
 
     def test_translation_ring_2(self):
         v_exp = np.zeros(3)
@@ -57,14 +59,17 @@ class TestSpatialOrientation(unittest.TestCase):
             + self.so.v_screen_optic_optic.rotate(self.so.r_optic_cam)
             + self.so.v_optic_cam_cam
         )
-        np.testing.assert_allclose(v_exp, v_calc.data.squeeze(), rtol=0, atol=1e-10)
+        np.testing.assert_allclose(
+            v_exp, v_calc.data.squeeze(), rtol=0, atol=1e-10)
 
     def test_rotation_ring_1(self):
         I_exp = np.eye(3)
         I_calc = self.so.r_optic_screen * self.so.r_cam_optic * self.so.r_screen_cam
-        np.testing.assert_allclose(I_exp, I_calc.as_matrix(), atol=1e-9, rtol=0)
+        np.testing.assert_allclose(
+            I_exp, I_calc.as_matrix(), atol=1e-9, rtol=0)
 
     def test_rotation_ring_2(self):
         I_exp = np.eye(3)
         I_calc = self.so.r_cam_screen * self.so.r_optic_cam * self.so.r_screen_optic
-        np.testing.assert_allclose(I_exp, I_calc.as_matrix(), atol=1e-9, rtol=0)
+        np.testing.assert_allclose(
+            I_exp, I_calc.as_matrix(), atol=1e-9, rtol=0)

--- a/opencsp/common/lib/deflectometry/test/test_image_processing.py
+++ b/opencsp/common/lib/deflectometry/test/test_image_processing.py
@@ -7,7 +7,6 @@ import unittest
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
 from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.app.sofast.lib.SofastParams import SofastParams
@@ -15,6 +14,7 @@ from opencsp.common.lib.camera.Camera import Camera
 import opencsp.common.lib.deflectometry.image_processing as ip
 from opencsp.common.lib.geometry.LoopXY import LoopXY
 from opencsp.common.lib.geometry.Vxy import Vxy
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.tool.hdf5_tools import load_hdf5_datasets
 
 
@@ -31,15 +31,12 @@ class TestImageProcessing(unittest.TestCase):
         cls.data_file_undefined = join(
             base_dir, 'calculations_undefined_mirror/data.h5'
         )
-        cls.data_file_multi = join(
-            base_dir, 'calculations_facet_ensemble/data.h5')
+        cls.data_file_multi = join(base_dir, 'calculations_facet_ensemble/data.h5')
 
         # Define component files
         cls.data_file_camera = join(base_dir, 'camera.h5')
-        cls.data_file_measurement_facet = join(
-            base_dir, 'measurement_facet.h5')
-        cls.data_file_measurement_ensemble = join(
-            base_dir, 'measurement_ensemble.h5')
+        cls.data_file_measurement_facet = join(base_dir, 'measurement_facet.h5')
+        cls.data_file_measurement_ensemble = join(base_dir, 'measurement_ensemble.h5')
         cls.data_file_calibration = join(base_dir, 'calibration.h5')
 
     def test_calc_mask_raw(self):
@@ -125,15 +122,13 @@ class TestImageProcessing(unittest.TestCase):
         data = load_hdf5_datasets(datasets, self.data_file_facet)
 
         # Perform calculation
-        loop_facet_exp = LoopXY.from_vertices(
-            Vxy(data['loop_optic_image_exp']))
+        loop_facet_exp = LoopXY.from_vertices(Vxy(data['loop_optic_image_exp']))
         loop_facet_refine = ip.refine_mask_perimeter(
             loop_facet_exp, Vxy(data['v_edges_image']), *args
         ).vertices.data.squeeze()
 
         # Test
-        np.testing.assert_allclose(
-            data['loop_facet_image_refine'], loop_facet_refine)
+        np.testing.assert_allclose(data['loop_facet_image_refine'], loop_facet_refine)
 
     def test_refine_facet_corners(self):
         """Tests image_processing.refine_facet_corners()"""
@@ -171,8 +166,7 @@ class TestImageProcessing(unittest.TestCase):
             ]
             data = load_hdf5_datasets(datasets, self.data_file_multi)
             v_facet_corners_image_exp = Vxy(data['v_facet_corners_image_exp'])
-            v_facet_centroid_image_exp = Vxy(
-                data['v_facet_centroid_image_exp'])
+            v_facet_centroid_image_exp = Vxy(data['v_facet_centroid_image_exp'])
 
             # Save expected data
             data_exp.append(data['loop_facet_image_refine'])
@@ -201,10 +195,8 @@ class TestImageProcessing(unittest.TestCase):
             'DataSofastCalculation/image_processing/facet_000/mask_processed',
         ]
         data = load_hdf5_datasets(datasets, self.data_file_facet)
-        measurement = Measurement.load_from_hdf(
-            self.data_file_measurement_facet)
-        calibration = ImageCalibrationScaling.load_from_hdf(
-            self.data_file_calibration)
+        measurement = Measurement.load_from_hdf(self.data_file_measurement_facet)
+        calibration = ImageCalibrationScaling.load_from_hdf(self.data_file_calibration)
 
         measurement.calibrate_fringe_images(calibration)
 
@@ -241,8 +233,7 @@ class TestImageProcessing(unittest.TestCase):
         mask = data['mask_processed']
         r_cam_optic = Rotation.from_rotvec(data['r_optic_cam_refine_1']).inv()
         u_pixel_pointing_cam = ip.calculate_active_pixels_vectors(mask, camera)
-        u_pixel_pointing_optic = u_pixel_pointing_cam.rotate(
-            r_cam_optic).data.squeeze()
+        u_pixel_pointing_optic = u_pixel_pointing_cam.rotate(r_cam_optic).data.squeeze()
 
         # Test
         np.testing.assert_allclose(

--- a/opencsp/common/lib/deflectometry/test/test_image_processing.py
+++ b/opencsp/common/lib/deflectometry/test/test_image_processing.py
@@ -23,7 +23,7 @@ class TestImageProcessing(unittest.TestCase):
     def setUpClass(cls):
         # Get test data location
         base_dir = os.path.join(
-            opencsp_code_dir, 'test/data/sofast_measurements'
+            opencsp_code_dir(), 'test/data/sofast_measurements'
         )
 
         # Define calculation data files

--- a/opencsp/common/lib/deflectometry/test/test_image_processing.py
+++ b/opencsp/common/lib/deflectometry/test/test_image_processing.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
 from opencsp.app.sofast.lib.Measurement import Measurement
 from opencsp.app.sofast.lib.SofastParams import SofastParams
@@ -23,7 +23,7 @@ class TestImageProcessing(unittest.TestCase):
     def setUpClass(cls):
         # Get test data location
         base_dir = os.path.join(
-            os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements'
+            opencsp_code_dir, 'test/data/sofast_measurements'
         )
 
         # Define calculation data files
@@ -31,12 +31,15 @@ class TestImageProcessing(unittest.TestCase):
         cls.data_file_undefined = join(
             base_dir, 'calculations_undefined_mirror/data.h5'
         )
-        cls.data_file_multi = join(base_dir, 'calculations_facet_ensemble/data.h5')
+        cls.data_file_multi = join(
+            base_dir, 'calculations_facet_ensemble/data.h5')
 
         # Define component files
         cls.data_file_camera = join(base_dir, 'camera.h5')
-        cls.data_file_measurement_facet = join(base_dir, 'measurement_facet.h5')
-        cls.data_file_measurement_ensemble = join(base_dir, 'measurement_ensemble.h5')
+        cls.data_file_measurement_facet = join(
+            base_dir, 'measurement_facet.h5')
+        cls.data_file_measurement_ensemble = join(
+            base_dir, 'measurement_ensemble.h5')
         cls.data_file_calibration = join(base_dir, 'calibration.h5')
 
     def test_calc_mask_raw(self):
@@ -122,13 +125,15 @@ class TestImageProcessing(unittest.TestCase):
         data = load_hdf5_datasets(datasets, self.data_file_facet)
 
         # Perform calculation
-        loop_facet_exp = LoopXY.from_vertices(Vxy(data['loop_optic_image_exp']))
+        loop_facet_exp = LoopXY.from_vertices(
+            Vxy(data['loop_optic_image_exp']))
         loop_facet_refine = ip.refine_mask_perimeter(
             loop_facet_exp, Vxy(data['v_edges_image']), *args
         ).vertices.data.squeeze()
 
         # Test
-        np.testing.assert_allclose(data['loop_facet_image_refine'], loop_facet_refine)
+        np.testing.assert_allclose(
+            data['loop_facet_image_refine'], loop_facet_refine)
 
     def test_refine_facet_corners(self):
         """Tests image_processing.refine_facet_corners()"""
@@ -166,7 +171,8 @@ class TestImageProcessing(unittest.TestCase):
             ]
             data = load_hdf5_datasets(datasets, self.data_file_multi)
             v_facet_corners_image_exp = Vxy(data['v_facet_corners_image_exp'])
-            v_facet_centroid_image_exp = Vxy(data['v_facet_centroid_image_exp'])
+            v_facet_centroid_image_exp = Vxy(
+                data['v_facet_centroid_image_exp'])
 
             # Save expected data
             data_exp.append(data['loop_facet_image_refine'])
@@ -195,8 +201,10 @@ class TestImageProcessing(unittest.TestCase):
             'DataSofastCalculation/image_processing/facet_000/mask_processed',
         ]
         data = load_hdf5_datasets(datasets, self.data_file_facet)
-        measurement = Measurement.load_from_hdf(self.data_file_measurement_facet)
-        calibration = ImageCalibrationScaling.load_from_hdf(self.data_file_calibration)
+        measurement = Measurement.load_from_hdf(
+            self.data_file_measurement_facet)
+        calibration = ImageCalibrationScaling.load_from_hdf(
+            self.data_file_calibration)
 
         measurement.calibrate_fringe_images(calibration)
 
@@ -233,7 +241,8 @@ class TestImageProcessing(unittest.TestCase):
         mask = data['mask_processed']
         r_cam_optic = Rotation.from_rotvec(data['r_optic_cam_refine_1']).inv()
         u_pixel_pointing_cam = ip.calculate_active_pixels_vectors(mask, camera)
-        u_pixel_pointing_optic = u_pixel_pointing_cam.rotate(r_cam_optic).data.squeeze()
+        u_pixel_pointing_optic = u_pixel_pointing_cam.rotate(
+            r_cam_optic).data.squeeze()
 
         # Test
         np.testing.assert_allclose(

--- a/opencsp/common/lib/deflectometry/test/test_spatial_processing.py
+++ b/opencsp/common/lib/deflectometry/test/test_spatial_processing.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.Measurement import Measurement
 import opencsp.common.lib.deflectometry.spatial_processing as sp
@@ -21,12 +21,14 @@ class TestSpatialProcessing(unittest.TestCase):
     def setUpClass(cls):
         # Get test data location
         base_dir = os.path.join(
-            os.path.dirname(opencsp.__file__), 'test/data/sofast_measurements'
+            opencsp_code_dir, 'test/data/sofast_measurements'
         )
 
         # Define test data files for single facet processing
-        cls.data_file_facet = os.path.join(base_dir, 'calculations_facet/data.h5')
-        cls.data_file_measurement = os.path.join(base_dir, 'measurement_facet.h5')
+        cls.data_file_facet = os.path.join(
+            base_dir, 'calculations_facet/data.h5')
+        cls.data_file_measurement = os.path.join(
+            base_dir, 'measurement_facet.h5')
 
         cls.display = Display.load_from_hdf(cls.data_file_facet)
         cls.camera = Camera.load_from_hdf(cls.data_file_facet)
@@ -50,7 +52,8 @@ class TestSpatialProcessing(unittest.TestCase):
         ).data.squeeze()
 
         # Test
-        np.testing.assert_allclose(data['v_cam_optic_cam_exp'], v_cam_optic_cam_exp)
+        np.testing.assert_allclose(
+            data['v_cam_optic_cam_exp'], v_cam_optic_cam_exp)
 
     def test_r_from_position(self):
         datasets = [
@@ -64,7 +67,8 @@ class TestSpatialProcessing(unittest.TestCase):
         # Perform calculation
         r_optic_cam_exp = (
             sp.r_from_position(
-                Vxyz(data['v_cam_optic_cam_exp']), self.display.v_cam_screen_cam
+                Vxyz(data['v_cam_optic_cam_exp']
+                     ), self.display.v_cam_screen_cam
             )
             .inv()
             .as_rotvec()
@@ -148,7 +152,8 @@ class TestSpatialProcessing(unittest.TestCase):
         )
 
         # Test
-        np.testing.assert_allclose(data['error_reprojection_2'], error_reproj_init)
+        np.testing.assert_allclose(
+            data['error_reprojection_2'], error_reproj_init)
 
     def test_refine_v_distance(self):
         datasets = [

--- a/opencsp/common/lib/deflectometry/test/test_spatial_processing.py
+++ b/opencsp/common/lib/deflectometry/test/test_spatial_processing.py
@@ -6,13 +6,13 @@ import unittest
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.Measurement import Measurement
 import opencsp.common.lib.deflectometry.spatial_processing as sp
 from opencsp.common.lib.camera.Camera import Camera
 from opencsp.common.lib.geometry.Vxy import Vxy
 from opencsp.common.lib.geometry.Vxyz import Vxyz
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.tool.hdf5_tools import load_hdf5_datasets
 
 
@@ -25,10 +25,8 @@ class TestSpatialProcessing(unittest.TestCase):
         )
 
         # Define test data files for single facet processing
-        cls.data_file_facet = os.path.join(
-            base_dir, 'calculations_facet/data.h5')
-        cls.data_file_measurement = os.path.join(
-            base_dir, 'measurement_facet.h5')
+        cls.data_file_facet = os.path.join(base_dir, 'calculations_facet/data.h5')
+        cls.data_file_measurement = os.path.join(base_dir, 'measurement_facet.h5')
 
         cls.display = Display.load_from_hdf(cls.data_file_facet)
         cls.camera = Camera.load_from_hdf(cls.data_file_facet)
@@ -52,8 +50,7 @@ class TestSpatialProcessing(unittest.TestCase):
         ).data.squeeze()
 
         # Test
-        np.testing.assert_allclose(
-            data['v_cam_optic_cam_exp'], v_cam_optic_cam_exp)
+        np.testing.assert_allclose(data['v_cam_optic_cam_exp'], v_cam_optic_cam_exp)
 
     def test_r_from_position(self):
         datasets = [
@@ -67,8 +64,7 @@ class TestSpatialProcessing(unittest.TestCase):
         # Perform calculation
         r_optic_cam_exp = (
             sp.r_from_position(
-                Vxyz(data['v_cam_optic_cam_exp']
-                     ), self.display.v_cam_screen_cam
+                Vxyz(data['v_cam_optic_cam_exp']), self.display.v_cam_screen_cam
             )
             .inv()
             .as_rotvec()
@@ -152,8 +148,7 @@ class TestSpatialProcessing(unittest.TestCase):
         )
 
         # Test
-        np.testing.assert_allclose(
-            data['error_reprojection_2'], error_reproj_init)
+        np.testing.assert_allclose(data['error_reprojection_2'], error_reproj_init)
 
     def test_refine_v_distance(self):
         datasets = [

--- a/opencsp/common/lib/deflectometry/test/test_spatial_processing.py
+++ b/opencsp/common/lib/deflectometry/test/test_spatial_processing.py
@@ -21,7 +21,7 @@ class TestSpatialProcessing(unittest.TestCase):
     def setUpClass(cls):
         # Get test data location
         base_dir = os.path.join(
-            opencsp_code_dir, 'test/data/sofast_measurements'
+            opencsp_code_dir(), 'test/data/sofast_measurements'
         )
 
         # Define test data files for single facet processing

--- a/opencsp/test/data/sofast_measurements/generate_downsampled_datasets.py
+++ b/opencsp/test/data/sofast_measurements/generate_downsampled_datasets.py
@@ -88,6 +88,6 @@ def downsample_dataset_1(base_dir):
 
 if __name__ == '__main__':
     dir_sample_data = os.path.join(
-        opencsp_code_dir, '../../sample_data/sofast/measurement_set_1'
+        opencsp_code_dir(), '../../sample_data/sofast/measurement_set_1'
     )
     downsample_dataset_1(dir_sample_data)

--- a/opencsp/test/data/sofast_measurements/generate_downsampled_datasets.py
+++ b/opencsp/test/data/sofast_measurements/generate_downsampled_datasets.py
@@ -7,7 +7,7 @@ import os
 
 import matplotlib.pyplot as plt
 
-import opencsp
+from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
 import opencsp.app.sofast.test.downsample_sofast_data as ds
@@ -28,7 +28,8 @@ def downsample_dataset_1(base_dir):
 
     # Define location of sample data
     file_measurement_facet = os.path.join(base_dir, 'measurement_facet.h5')
-    file_measurement_ensemble = os.path.join(base_dir, 'measurement_ensemble.h5')
+    file_measurement_ensemble = os.path.join(
+        base_dir, 'measurement_ensemble.h5')
     file_camera = os.path.join(base_dir, 'camera.h5')
     file_display_1 = os.path.join(base_dir, 'display_distorted_2d.h5')
     file_display_2 = os.path.join(base_dir, 'display_distorted_3d.h5')
@@ -43,7 +44,8 @@ def downsample_dataset_1(base_dir):
     # Load data
     camera = dd.downsample_camera(file_camera, n_ds)
     measurement_facet = ds.downsample_measurement(file_measurement_facet, n_ds)
-    measurement_ensemble = ds.downsample_measurement(file_measurement_ensemble, n_ds)
+    measurement_ensemble = ds.downsample_measurement(
+        file_measurement_ensemble, n_ds)
     display_1 = Display.load_from_hdf(file_display_1)
     display_2 = Display.load_from_hdf(file_display_2)
     display_3 = Display.load_from_hdf(file_display_3)
@@ -63,9 +65,11 @@ def downsample_dataset_1(base_dir):
         os.path.join(dir_dataset_out, os.path.basename(file_measurement_facet))
     )
     measurement_ensemble.save_to_hdf(
-        os.path.join(dir_dataset_out, os.path.basename(file_measurement_ensemble))
+        os.path.join(dir_dataset_out, os.path.basename(
+            file_measurement_ensemble))
     )
-    camera.save_to_hdf(os.path.join(dir_dataset_out, os.path.basename(file_camera)))
+    camera.save_to_hdf(os.path.join(
+        dir_dataset_out, os.path.basename(file_camera)))
     display_1.save_to_hdf(
         os.path.join(dir_dataset_out, os.path.basename(file_display_1))
     )
@@ -84,6 +88,6 @@ def downsample_dataset_1(base_dir):
 
 if __name__ == '__main__':
     dir_sample_data = os.path.join(
-        os.path.dirname(opencsp.__file__), '../../sample_data/sofast/measurement_set_1'
+        opencsp_code_dir, '../../sample_data/sofast/measurement_set_1'
     )
     downsample_dataset_1(dir_sample_data)

--- a/opencsp/test/data/sofast_measurements/generate_downsampled_datasets.py
+++ b/opencsp/test/data/sofast_measurements/generate_downsampled_datasets.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 from opencsp.common.lib.opencsp_path.opencsp_root_path import opencsp_code_dir
 from opencsp.common.lib.deflectometry.Display import Display
 from opencsp.app.sofast.lib.ImageCalibrationScaling import ImageCalibrationScaling
-import opencsp.app.sofast.test.downsample_sofast_data as ds
+import opencsp.test.data.sofast_measurements.downsample_sofast_data as ds
 import opencsp.common.lib.test.downsample_data as dd
 
 
@@ -28,8 +28,7 @@ def downsample_dataset_1(base_dir):
 
     # Define location of sample data
     file_measurement_facet = os.path.join(base_dir, 'measurement_facet.h5')
-    file_measurement_ensemble = os.path.join(
-        base_dir, 'measurement_ensemble.h5')
+    file_measurement_ensemble = os.path.join(base_dir, 'measurement_ensemble.h5')
     file_camera = os.path.join(base_dir, 'camera.h5')
     file_display_1 = os.path.join(base_dir, 'display_distorted_2d.h5')
     file_display_2 = os.path.join(base_dir, 'display_distorted_3d.h5')
@@ -44,8 +43,7 @@ def downsample_dataset_1(base_dir):
     # Load data
     camera = dd.downsample_camera(file_camera, n_ds)
     measurement_facet = ds.downsample_measurement(file_measurement_facet, n_ds)
-    measurement_ensemble = ds.downsample_measurement(
-        file_measurement_ensemble, n_ds)
+    measurement_ensemble = ds.downsample_measurement(file_measurement_ensemble, n_ds)
     display_1 = Display.load_from_hdf(file_display_1)
     display_2 = Display.load_from_hdf(file_display_2)
     display_3 = Display.load_from_hdf(file_display_3)
@@ -65,11 +63,9 @@ def downsample_dataset_1(base_dir):
         os.path.join(dir_dataset_out, os.path.basename(file_measurement_facet))
     )
     measurement_ensemble.save_to_hdf(
-        os.path.join(dir_dataset_out, os.path.basename(
-            file_measurement_ensemble))
+        os.path.join(dir_dataset_out, os.path.basename(file_measurement_ensemble))
     )
-    camera.save_to_hdf(os.path.join(
-        dir_dataset_out, os.path.basename(file_camera)))
+    camera.save_to_hdf(os.path.join(dir_dataset_out, os.path.basename(file_camera)))
     display_1.save_to_hdf(
         os.path.join(dir_dataset_out, os.path.basename(file_display_1))
     )


### PR DESCRIPTION
### Updated OpenCSP deflectometry apps/functions to reflect suggested changes from code review.
- Updated SlopeSolverData to dataclass with attributes set to `None`
- Added `__copy__()` method to SpatialOrientation.py
- Changed reference to `os.path.dirname(opencsp.__file__)` to `opencsp_root_path.opencsp_code_dir()` in all deflectometry/sofast/fixed_pattern related files.
- Added reprojection/ray intersection error printing output in FixedPatternSetupCalibrate.py. This aided in tracking down and fixing a code bug.
- Where necessary, re-alphabetized imports and removed unused imports.
- Fixed error in "example_scene_reconstruction" file.