### PR TITLE
Camera calibration tests

### DIFF
--- a/.github/workflows/ubi8.yml
+++ b/.github/workflows/ubi8.yml
@@ -40,4 +40,4 @@ jobs:
         run: |
           python3 -m pip install -r ../requirements.txt
           export PYTHONPATH=$PWD/../
-          pytest --color=yes -rs -vv --cov=. --cov-report term --cov-config=.coveragerc -s -k test_image_points
+          pytest --color=yes -rs -vv --cov=. --cov-report term --cov-config=.coveragerc

--- a/.github/workflows/ubi8.yml
+++ b/.github/workflows/ubi8.yml
@@ -40,4 +40,4 @@ jobs:
         run: |
           python3 -m pip install -r ../requirements.txt
           export PYTHONPATH=$PWD/../
-          pytest --color=yes -rs -vv --cov=. --cov-report term --cov-config=.coveragerc
+          pytest --color=yes -rs -vv --cov=. --cov-report term --cov-config=.coveragerc -s -k test_image_points

--- a/opencsp/app/camera_calibration/test/test_camera_calibration.py
+++ b/opencsp/app/camera_calibration/test/test_camera_calibration.py
@@ -158,7 +158,7 @@ class TestCameraCalibration:
     def test_calibration_error(self):
         np.testing.assert_allclose(self.calibration_error, self.calibration_error_exp)
 
-    def reprojection_errors(self):
+    def test_reprojection_errors(self):
         np.testing.assert_allclose(
             self.reprojection_errors, self.reprojection_errors_exp
         )

--- a/opencsp/app/camera_calibration/test/test_camera_calibration.py
+++ b/opencsp/app/camera_calibration/test/test_camera_calibration.py
@@ -40,6 +40,7 @@ class TestCameraCalibration:
 
         # Find all files
         files = glob(image_pattern)
+        files.sort()
 
         # Load images and find corners
         images = []

--- a/opencsp/app/camera_calibration/test/test_camera_calibration.py
+++ b/opencsp/app/camera_calibration/test/test_camera_calibration.py
@@ -133,6 +133,16 @@ class TestCameraCalibration:
             cls.calibration_error_exp = data['calibration_error']
             cls.reprojection_errors_exp = data['reprojection_errors']
 
+            print([a.data[:, :2] for a in p_image[:2]])
+            print('\n')
+            print(np.array([a.data[:, :2] for a in p_image[:2]]))
+            print('\n')
+            print(cls.p_image_points[:2, :2, :2])
+            # pts_test = cls.p_image_points[:2, :2, :2]
+            # pts_test_exp = cls.p_image_points_exp[:2, :2, :2]
+            # print(pts_test_exp)
+            # print(pts_test)
+
     def test_image_points(self):
         np.testing.assert_allclose(self.p_image_points, self.p_image_points_exp)
 

--- a/opencsp/app/camera_calibration/test/test_camera_calibration.py
+++ b/opencsp/app/camera_calibration/test/test_camera_calibration.py
@@ -134,16 +134,6 @@ class TestCameraCalibration:
             cls.calibration_error_exp = data['calibration_error']
             cls.reprojection_errors_exp = data['reprojection_errors']
 
-            print([a.data[:, :2] for a in p_image[:2]])
-            print('\n')
-            print(np.array([a.data[:, :2] for a in p_image[:2]]))
-            print('\n')
-            print(cls.p_image_points[:2, :2, :2])
-            # pts_test = cls.p_image_points[:2, :2, :2]
-            # pts_test_exp = cls.p_image_points_exp[:2, :2, :2]
-            # print(pts_test_exp)
-            # print(pts_test)
-
     def test_image_points(self):
         np.testing.assert_allclose(self.p_image_points, self.p_image_points_exp)
 

--- a/opencsp/app/camera_calibration/test/test_camera_calibration.py
+++ b/opencsp/app/camera_calibration/test/test_camera_calibration.py
@@ -133,11 +133,21 @@ class TestCameraCalibration:
             cls.calibration_error_exp = data['calibration_error']
             cls.reprojection_errors_exp = data['reprojection_errors']
 
-            print([a.data[:, :2] for a in p_image[:2]])
-            print('\n')
-            print(np.array([a.data[:, :2] for a in p_image[:2]]))
-            print('\n')
-            print(cls.p_image_points[:2, :2, :2])
+            # idx = np.argmin(np.abs(cls.p_image_points - 1304.8412))
+            idx = np.argmin(np.abs(cls.p_image_points - 1409.4342))
+            print(idx)
+            print(cls.p_image_points.flatten()[idx])
+
+            loc = np.where(cls.p_image_points == cls.p_image_points.flatten()[idx])
+            print(loc)
+
+            print(cls.p_image_points.shape)
+
+            # print([a.data[:, :2] for a in p_image[:2]])
+            # print('\n')
+            # print(np.array([a.data[:, :2] for a in p_image[:2]]))
+            # print('\n')
+            # print(cls.p_image_points[:2, :2, :2])
             # pts_test = cls.p_image_points[:2, :2, :2]
             # pts_test_exp = cls.p_image_points_exp[:2, :2, :2]
             # print(pts_test_exp)

--- a/opencsp/app/camera_calibration/test/test_camera_calibration.py
+++ b/opencsp/app/camera_calibration/test/test_camera_calibration.py
@@ -134,21 +134,11 @@ class TestCameraCalibration:
             cls.calibration_error_exp = data['calibration_error']
             cls.reprojection_errors_exp = data['reprojection_errors']
 
-            # idx = np.argmin(np.abs(cls.p_image_points - 1304.8412))
-            idx = np.argmin(np.abs(cls.p_image_points - 1409.4342))
-            print(idx)
-            print(cls.p_image_points.flatten()[idx])
-
-            loc = np.where(cls.p_image_points == cls.p_image_points.flatten()[idx])
-            print(loc)
-
-            print(cls.p_image_points.shape)
-
-            # print([a.data[:, :2] for a in p_image[:2]])
-            # print('\n')
-            # print(np.array([a.data[:, :2] for a in p_image[:2]]))
-            # print('\n')
-            # print(cls.p_image_points[:2, :2, :2])
+            print([a.data[:, :2] for a in p_image[:2]])
+            print('\n')
+            print(np.array([a.data[:, :2] for a in p_image[:2]]))
+            print('\n')
+            print(cls.p_image_points[:2, :2, :2])
             # pts_test = cls.p_image_points[:2, :2, :2]
             # pts_test_exp = cls.p_image_points_exp[:2, :2, :2]
             # print(pts_test_exp)


### PR DESCRIPTION
- Added sort statement to fix errors with CameraCalibration unit tests.
- Only failed test is test_with_attrfile
- Added missing `test_` prefix to reprojection error test so that it runs.