### PR TITLE
Remove undefined parallel code from figure_management

### DIFF
--- a/.github/workflows/windows2022.yml
+++ b/.github/workflows/windows2022.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       - name: Install Deps
         run: |

--- a/.github/workflows/windows2022.yml
+++ b/.github/workflows/windows2022.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install Deps
         run: |

--- a/opencsp/common/lib/render/figure_management.py
+++ b/opencsp/common/lib/render/figure_management.py
@@ -531,7 +531,7 @@ def save_all_figures(output_path: str, format: str = None):
         - txts: list[str] The list of image descriptor text files
         - failed: list[RenderControlFigureRecord] The list of figure records that failed to save
     """
-    global fig_record_list # TODO: convert from global to class member or save_all_figures parameter
+    global fig_record_list  # TODO: convert from global to class member or save_all_figures parameter
     figs: list[str] = []
     txts: list[str] = []
     failed: list[RenderControlFigureRecord] = []

--- a/opencsp/common/lib/render/figure_management.py
+++ b/opencsp/common/lib/render/figure_management.py
@@ -545,7 +545,7 @@ def save_all_figures(output_path: str, format: str = None):
         err_msg = f"RuntimeError: figure_management.save_all_figures: failed to save figure {fig_record.figure_num} \"{fig_record.name}\""
         lt.error(err_msg)
         failed.append(fig_record)
-        raise(ex)
+        raise (ex)
 
     return figs, txts, failed
 

--- a/opencsp/common/lib/render/figure_management.py
+++ b/opencsp/common/lib/render/figure_management.py
@@ -520,31 +520,18 @@ def print_figure_summary() -> None:
 def save_all_figures(output_path: str, format: str = None):
     """Saves all figures opened with setup_figure (since reset_figure_management) to the given directory.
 
-    The purpose for timeout is to let the program fail gracefully
-    during the rare instances when matplotlib's save routine goes
-    out to lunch.
-
-    Note: if a timeout is specified, and the matplotlib save
-    routine fails to complete, the running thread may continue to
-    evaluate forever.  For this reason, for processes that are
-    expected to stop executing on their own, it is recommended that:
-        - the calling code be executed as a subprocess
-        - the subprocess is terminated when save_all returns
-
     Args:
     -----
         - output_path (str): The directory to save figures to.
         - format (str): The file format for figures. None for RenderControlFigureRecord.save default. Defaults to None.
-        - timeout (float): How many seconds to wait for the image to be saved. None to wait indefinitely. Defaults to None. FIXME make this work on windows.
-        - raise_on_timeout (bool): Whether to raise an exception if timeout elapse. Defaults to False.
 
     Returns:
     --------
         - figs: list[str] The list of image files
         - txts: list[str] The list of image descriptor text files
-        - failed: list[RenderControlFigureRecord] The list of figure records that failed to save (only returned if timeout is not None)
+        - failed: list[RenderControlFigureRecord] The list of figure records that failed to save
     """
-    global fig_record_list # TODO: convert to class member or save_all_figures parameter
+    global fig_record_list # TODO: convert from global to class member or save_all_figures parameter
     figs: list[str] = []
     txts: list[str] = []
     failed: list[RenderControlFigureRecord] = []

--- a/opencsp/common/lib/render/figure_management.py
+++ b/opencsp/common/lib/render/figure_management.py
@@ -517,7 +517,7 @@ def print_figure_summary() -> None:
         fig_record.print_comments()
 
 
-def save_all_figures(output_path: str, format: str = None, timeout: float = None, raise_on_timeout=False):
+def save_all_figures(output_path: str, format: str = None):
     """Saves all figures opened with setup_figure (since reset_figure_management) to the given directory.
 
     The purpose for timeout is to let the program fail gracefully
@@ -544,51 +544,22 @@ def save_all_figures(output_path: str, format: str = None, timeout: float = None
         - txts: list[str] The list of image descriptor text files
         - failed: list[RenderControlFigureRecord] The list of figure records that failed to save (only returned if timeout is not None)
     """
-    global fig_record_list
+    global fig_record_list # TODO: convert to class member or save_all_figures parameter
     figs: list[str] = []
     txts: list[str] = []
     failed: list[RenderControlFigureRecord] = []
 
-    if timeout == None:
+    try:
         for fig_record in fig_record_list:
-            t1, t2 = fig_record.save(output_path, format=format, close_after_save=False)
-            figs.append(t1)
-            txts.append(t2)
+            fig_file, txt_file = fig_record.save(output_path, format=format, close_after_save=False)
+            figs.append(fig_file)
+            txts.append(txt_file)
+    except RuntimeError:
+        err_msg = f"RuntimeError: figure_management.save_all_figures: failed to save figure {fig_record.figure_num} \"{fig_record.name}\""
+        lt.error(err_msg)
+        failed.append(fig_record)
 
-        return figs, txts
-    else:
-        # Save each figure with a timeout on how long to wait for the figure to be saved.
-        from threading import Thread
-
-        for fig_record in fig_record_list:
-            # start the save
-            results = []
-            t = Thread(
-                target=lambda: results.append(fig_record.save(output_path, format=format, close_after_save=False))
-            )
-            t.start()
-
-            # wait for the save to finish
-            t.join(timeout)
-            if not t.is_alive():
-                # join the thread again, in case it finished between the timeout and the is_alive()
-                t.join(0.1)
-                # done saving the figure
-                # get the results and register the success
-                t1, t2 = results[0]
-                figs.append(t1)
-                txts.append(t2)
-                break
-
-            # the figure failed to save before the timeout
-            err_msg = f"Error: figure_management.save_all_figures: failed to save figure {fig_record.figure_num} \"{fig_record.name}\""
-            if raise_on_timeout:
-                lt.error_and_raise(RuntimeError, err_msg)
-            else:
-                lt.error(err_msg)
-            failed.append(fig_record)
-
-        return figs, txts, failed
+    return figs, txts, failed
 
 
 def formatted_fig_display(block: bool = False) -> None:

--- a/opencsp/common/lib/render/figure_management.py
+++ b/opencsp/common/lib/render/figure_management.py
@@ -541,10 +541,11 @@ def save_all_figures(output_path: str, format: str = None):
             fig_file, txt_file = fig_record.save(output_path, format=format, close_after_save=False)
             figs.append(fig_file)
             txts.append(txt_file)
-    except RuntimeError:
+    except Exception as ex:
         err_msg = f"RuntimeError: figure_management.save_all_figures: failed to save figure {fig_record.figure_num} \"{fig_record.name}\""
         lt.error(err_msg)
         failed.append(fig_record)
+        raise(ex)
 
     return figs, txts, failed
 

--- a/opencsp/common/lib/render/test/test_figure_management.py
+++ b/opencsp/common/lib/render/test/test_figure_management.py
@@ -86,28 +86,6 @@ class test_figure_management(unittest.TestCase):
         figs_txts = fm.save_all_figures(self.dir_out)
         self.assert_exists(figs_txts, 2)
 
-    def test_save_all_figures_timeout_0(self):
-        """Test that saving a figure with a 0s timeout will always fail."""
-        name = "line_2"
-        fm.reset_figure_management()
-
-        figure_control = rcfg.RenderControlFigure(tile_array=(1, 1), tile_square=True)
-        fig_record = fm.setup_figure(
-            figure_control, name=name, code_tag=f"{__file__}.test_save_all_figures_timeout_0()"
-        )
-        view = fig_record.view
-        line = list(range(100))
-        view.draw_p_list(line)
-
-        with self.assertRaisesRegex(
-            (RuntimeError, subprocess.TimeoutExpired),
-            r".*failed to save.*",
-            msg="Failed to time out in 0 seconds while trying to save figure",
-        ):
-            figs, txts, failed = fm.save_all_figures(self.dir_out, timeout=0, raise_on_timeout=True)
-            self.assertEqual(len(figs), 0)
-            self.assertEqual(len(txts), 0)
-
     def _figure_manager_timeout_1(self):
         """Helper method. Generate a figure manager and populate it with one figure record that will never finish saving."""
         name = "line_3"
@@ -135,11 +113,6 @@ class test_figure_management(unittest.TestCase):
 
         return fm
 
-    def save_all_figures_fail_and_raise_executor(self):
-        """try to save (should fail and raise an error)"""
-        fm = self._figure_manager_timeout_1()
-        figs, txts, failed = fm.save_all_figures(self.dir_out, timeout=1, raise_on_timeout=True)
-
     def test_save_all_figures_fail_and_raise(self):
         """Verifies that the save_all_figures() method will eventually time out for a figure record whose save() method never finishes."""
         lt.logger(os.path.join(root_path.opencsp_temporary_dir(), "tmp.log"))
@@ -163,7 +136,7 @@ class test_figure_management(unittest.TestCase):
     def save_all_figures_fail_no_raise_executor(self):
         """try to save (should fail and return the failed figure record)"""
         fm = self._figure_manager_timeout_1()
-        figs, txts, failed = fm.save_all_figures(self.dir_out, timeout=1)
+        figs, txts, failed = fm.save_all_figures(self.dir_out)
         self.assertEqual(1, len(failed), "save_all_figures() didn't return the correct number of figure records")
         fig_record = fm.fig_record_list[0]
         self.assertIn(fig_record, failed, "save_all_figures() didn't return the correct figure record")
@@ -182,22 +155,6 @@ class test_figure_management(unittest.TestCase):
             )
             stdout = [line.val for line in stdout]
             self.assertIn("Failed gracefully", stdout, f"Subprocess didn't exit correctly.")
-
-    def test_save_all_figures_notimeout_100(self):
-        """Test that with a long 100 second timeout, the figure is saved."""
-        name = "line_4"
-        fm.reset_figure_management()
-
-        figure_control = rcfg.RenderControlFigure(tile_array=(1, 1), tile_square=True)
-        fig_record = fm.setup_figure(
-            figure_control, name=name, code_tag=f"{__file__}.test_save_all_figures_notimeout_100()"
-        )
-        view = fig_record.view
-        line = list(range(100))
-        view.draw_p_list(line)
-
-        figs_txts_fails = fm.save_all_figures(self.dir_out, timeout=100, raise_on_timeout=True)
-        self.assert_exists(figs_txts_fails, 1)
 
 
 if __name__ == '__main__':

--- a/opencsp/common/lib/render/test/test_figure_management.py
+++ b/opencsp/common/lib/render/test/test_figure_management.py
@@ -113,49 +113,6 @@ class test_figure_management(unittest.TestCase):
 
         return fm
 
-    def test_save_all_figures_fail_and_raise(self):
-        """Verifies that the save_all_figures() method will eventually time out for a figure record whose save() method never finishes."""
-        lt.logger(os.path.join(root_path.opencsp_temporary_dir(), "tmp.log"))
-        if os.name == "nt":
-            pass  # threaded timeouts in save_all_figures not yet working on windows
-        else:
-            stderr = st.run(
-                f"{sys.executable} {__file__} --funcname save_all_figures_fail_and_raise_executor",
-                None,
-                ignore_return_code=True,
-                timeout=10.0,
-            )
-            found = False
-            for line in stderr:
-                line = line.val.lower()
-                if "failed to save figure" in line:
-                    found = True
-            if not found:
-                self.fail("Failed to time out in 1 second")
-
-    def save_all_figures_fail_no_raise_executor(self):
-        """try to save (should fail and return the failed figure record)"""
-        fm = self._figure_manager_timeout_1()
-        figs, txts, failed = fm.save_all_figures(self.dir_out)
-        self.assertEqual(1, len(failed), "save_all_figures() didn't return the correct number of figure records")
-        fig_record = fm.fig_record_list[0]
-        self.assertIn(fig_record, failed, "save_all_figures() didn't return the correct figure record")
-        lt.error("Failed gracefully")
-        sys.exit(0)  # force this process to exit (waits forever on save_all_figures())
-
-    def test_save_all_figures_fail_no_raise(self):
-        """Verifies that the save_all_figures() method will eventually time out for a figure record and will return the failing record."""
-        if os.name == "nt":
-            pass  # threaded timeouts in save_all_figures not yet working on windows
-        else:
-            stdout = st.run(
-                f"{sys.executable} {__file__} --funcname save_all_figures_fail_no_raise_executor",
-                ignore_return_code=True,
-                timeout=10.0,
-            )
-            stdout = [line.val for line in stdout]
-            self.assertIn("Failed gracefully", stdout, f"Subprocess didn't exit correctly.")
-
 
 if __name__ == '__main__':
     import argparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@
 # packages that can be installed with conda on solo #condapkgs
 h5py >= 3.10.0
 imageio >= 2.34.0
-matplotlib >= 3.8.3
+matplotlib <= 3.8.4
 numpy >= 1.26.4
 pandas >= 2.2.1
 pillow >= 10.2.0


### PR DESCRIPTION
## Summary of changes:

- Remove parallel branch from save_all_figures
- Remove timeout and raise_on_timeout parameters from save_all_figures
- Update unit tests accordingly
- Fix matplotlib version to <= 3.8.4

Fixes #88
Fixes #109