### PR TITLE
Add initial templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/code-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/code-bug-report.yml
@@ -1,0 +1,74 @@
+name: Code Bug Report
+description: File a code bug report.
+title: "[Code Bug]: "
+labels: ["code bug", "triage"]
+assignees:
+  - e10harvey, bbean23, braden6521
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      options:
+        - develop@5fd52b5
+        - main@8c65300
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: What OS are you seeing this on?
+      multiple: true
+      options:
+        - Windows
+        - Linux
+        - MacOS
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Relevant dependency versions
+      description: Please copy and paste any relevant dependency versions (hint python3 --version, ffmpeg -version, pip list). This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: python script that produces the error
+      description: Please copy and paste the code that produces the error. This will be automatically formatted into code, so no need for backticks.
+      render: python
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant console output
+      description: Please copy and paste any relevant console output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: contribution-guidelines
+    attributes:
+      label: Contribution Guidelines
+      description: By submitting this issue, you agree to follow our [contribution guidelines](https://github.com/sandialabs/OpenCSP/blob/main/CONTRIBUTING.md). 
+      options:
+        - label: I agree to follow this project's contribution guidelines
+          required: true

--- a/.github/ISSUE_TEMPLATE/code-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/code-feature-request.yml
@@ -1,0 +1,63 @@
+name: Code Feature Request
+description: Request a new code feature.
+title: "[Code Feature]: "
+labels: ["code feature", "under review"]
+assignees:
+  - e10harvey, bbean23, braden6521
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature
+      description: Also, describe the feature you would like.
+      placeholder: Describe what you want!
+      value: "42!"
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Feature
+      description: Also tell us, what are your requirements?
+      placeholder: As a X, I need to Y, so that I can Z.
+      value: "42!"
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: What OS do you intend to use this on?
+      multiple: true
+      options:
+        - Windows
+        - Linux
+        - MacOS
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Also tell us, what third party dependencies does this feature require?
+      placeholder: foobar v1000
+      value: "42!"
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution-guidelines
+    attributes:
+      label: Contribution Guidelines
+      description: By submitting this issue, you agree to follow our [contribution guidelines](https://github.com/sandialabs/OpenCSP/blob/main/CONTRIBUTING.md). 
+      options:
+        - label: I agree to follow this project's contribution guidelines
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: OpenCSP Community Support
+    url: https://github.com/sandialabs/OpenCSP/discussions
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/data-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/data-bug-report.yml
@@ -1,0 +1,82 @@
+name: Data Bug Report
+description: File a data bug report.
+title: "[Data Bug]: "
+labels: ["data bug", "triage"]
+assignees:
+  - e10harvey, bbean23, braden6521
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      options:
+        - develop@5fd52b5
+        - main@8c65300
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: What OS are you seeing this on?
+      multiple: true
+      options:
+        - Windows
+        - Linux
+        - MacOS
+  - type: input
+    id: data-link
+    attributes:
+      label: Data link
+      description: How can we access the data you're having trouble with?
+      placeholder: ex. https://github.com/sandialabs/OpenCSP/tree/develop/opencsp/app/sofast/test/data/input/SofastConfiguration
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Relevant dependency versions
+      description: Please copy and paste any relevant dependency versions (hint python3 --version, ffmpeg -version, pip list). This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: python script that produces the error
+      description: Please copy and paste the code that produces the error. This will be automatically formatted into code, so no need for backticks.
+      render: python
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant console output
+      description: Please copy and paste any relevant console output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: contribution-guidelines
+    attributes:
+      label: Contribution Guidelines
+      description: By submitting this issue, you agree to follow our [contribution guidelines](https://github.com/sandialabs/OpenCSP/blob/main/CONTRIBUTING.md). 
+      options:
+        - label: I agree to follow this project's contribution guidelines
+          required: true

--- a/.github/ISSUE_TEMPLATE/data-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/data-feature-request.yml
@@ -1,0 +1,63 @@
+name: Data Feature Request
+description: Request a new data feature.
+title: "[Data Feature]: "
+labels: ["data feature", "under review"]
+assignees:
+  - e10harvey, bbean23, braden6521
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature
+      description: Also, describe the feature you would like.
+      placeholder: Describe what you want!
+      value: "42!"
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Feature
+      description: Also tell us, what are your requirements?
+      placeholder: As a X, I need to Y, so that I can Z.
+      value: "42!"
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: What OS do you intend to use this on?
+      multiple: true
+      options:
+        - Windows
+        - Linux
+        - MacOS
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Also tell us, what third party dependencies does this feature require?
+      placeholder: foobar v1000
+      value: "42!"
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution-guidelines
+    attributes:
+      label: Contribution Guidelines
+      description: By submitting this issue, you agree to follow our [contribution guidelines](https://github.com/sandialabs/OpenCSP/blob/main/CONTRIBUTING.md). 
+      options:
+        - label: I agree to follow this project's contribution guidelines
+          required: true


### PR DESCRIPTION
## Summary of changes
Add initial code and data bug/feature templates.
Add get help option.

You can try out these templates here: https://github.com/e10harvey/OpenCSP/issues/new/choose. Feel free to create issues too.