### PR TITLE
Fix example docs and background width

### DIFF
--- a/doc/source/_static/full_width_theme.css
+++ b/doc/source/_static/full_width_theme.css
@@ -1,0 +1,5 @@
+.wy-nav-content {
+  height: 100%;
+  max-width: 100% !important;
+  margin: auto;
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,4 +68,5 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ['_static']
+html_css_files = ['table_theme.css']

--- a/example/scene_reconstruction/example_scene_reconstruction.py
+++ b/example/scene_reconstruction/example_scene_reconstruction.py
@@ -20,6 +20,7 @@ def scene_reconstruction(dir_output, dir_input):
         The directory where the output files, including point locations and calibration figures, will be saved.
     dir_input : str
         The directory containing the input files needed for scene reconstruction. This includes:
+
         - 'camera.h5': HDF5 file containing camera parameters.
         - 'known_point_locations.csv': CSV file with known point locations.
         - 'aruco_marker_images/NAME.JPG': Directory containing images of Aruco markers.
@@ -29,6 +30,7 @@ def scene_reconstruction(dir_output, dir_input):
     Notes
     -----
     This function performs the following steps:
+
     1. Loads the camera parameters from an HDF5 file.
     2. Loads known point locations, point pair distances, and alignment points from CSV files.
     3. Initializes the SceneReconstruction object with the camera parameters and known point locations.


### PR DESCRIPTION
## Purpose

Fix the formatting of our readthedocs documentation. E.g., see https://opencsp.readthedocs.io/en/main/example/scene_reconstruction/config.html.

## Summary of changes

Add css style to expand width of white background to entire screen.
Fix doc-string format such that lists include newlines between elements.

## Implementation notes

Checked via `./make_docs.sh && open html/index.html`

## Submission checklist
- [x] Target branch is `develop`, not `main`
- [x] Existing tests are updated or new tests were added
- [x] `opencsp/test/test_DocStringsExist.py` are verified to include this change or have been updated accordingly
- [x] .rst file(s) under `doc/` are verified to include this change or have been updated accordingly

## Additional information

_Please provide any additional information here._