### PR TITLE
Fix test_with_attrfile bug and re-enable test

### DIFF
--- a/opencsp/common/lib/file/AttributesManager.py
+++ b/opencsp/common/lib/file/AttributesManager.py
@@ -62,6 +62,33 @@ class AttributesManager:
     def _register_parser_class(cls, parser_class: type[aap.AbstractAttributeParser]):
         _registered_parser_classes.add(parser_class)
 
+    def get_subclass_parser_classes(self, parser_class: type[aap.AbstractAttributeParser]):
+        """
+        Returns a list of all parsers that are subclasses of the given parser_class.
+
+        Parameters
+        ----------
+        parser_class : type[aap.AbstractAttributeParser]
+            The parser class to search for.
+
+        Returns
+        -------
+        subclass_parsers : list[aap.AbstractAttributeParser]
+            If parsers are found, a list of all parsers that are subclasses of the given parser_class. Otherwise, None.
+        """
+        subclass_parsers: list[aap.AbstractAttributeParser] = []
+        for parser in self.parsers:
+            if isinstance(parser, parser_class):
+                subclass_parsers.append(parser)
+
+        if len(subclass_parsers) == 0:
+            lt.debug(
+                f"In AttributesManager.get_parser(): found no subclass parsers matching parser class {parser_class}"
+            )
+            return None
+        else:
+            return subclass_parsers
+
     def get_parser(
         self, parser_class: type[aap.AbstractAttributeParser], error_on_not_found=True
     ) -> aap.AbstractAttributeParser:
@@ -80,27 +107,7 @@ class AttributesManager:
         if parser_class in self.generic_parsers:
             return self.generic_parsers[parser_class]
 
-        # find all parsers that are a subclass of the requested parser_class
-        subclass_parsers: list[aap.AbstractAttributeParser] = []
-        for parser in self.parsers:
-            if isinstance(parser, parser_class):
-                subclass_parsers.append(parser)
-        if len(subclass_parsers) == 1:
-            return subclass_parsers[0]
-        if len(subclass_parsers) == 0:
-            if error_on_not_found:
-                lt.error_and_raise(
-                    RuntimeError,
-                    "Programmer error in AttributesManager.get_parser(): "
-                    + f"there is an unregistered parser class {parser_class}! All AbstractAttributeParsers should "
-                    + "register themselves with RegisterClass() when their file is imported to prevent this error.",
-                )
-            else:
-                return None
-
-        # more than one subclass found, just return the first one
-        lt.debug(f"In AttributesManager.get_parser(): found more than one parser matching parser class {parser_class}")
-        return subclass_parsers[0]
+        return None
 
     def set_parser(self, parser: aap.AbstractAttributeParser):
         """Sets the given parser as the default parser for the given class."""

--- a/opencsp/common/lib/file/AttributesManager.py
+++ b/opencsp/common/lib/file/AttributesManager.py
@@ -62,33 +62,6 @@ class AttributesManager:
     def _register_parser_class(cls, parser_class: type[aap.AbstractAttributeParser]):
         _registered_parser_classes.add(parser_class)
 
-    def get_subclass_parser_classes(self, parser_class: type[aap.AbstractAttributeParser]):
-        """
-        Returns a list of all parsers that are subclasses of the given parser_class.
-
-        Parameters
-        ----------
-        parser_class : type[aap.AbstractAttributeParser]
-            The parser class to search for.
-
-        Returns
-        -------
-        subclass_parsers : list[aap.AbstractAttributeParser]
-            If parsers are found, a list of all parsers that are subclasses of the given parser_class. Otherwise, None.
-        """
-        subclass_parsers: list[aap.AbstractAttributeParser] = []
-        for parser in self.parsers:
-            if isinstance(parser, parser_class):
-                subclass_parsers.append(parser)
-
-        if len(subclass_parsers) == 0:
-            lt.debug(
-                f"In AttributesManager.get_parser(): found no subclass parsers matching parser class {parser_class}"
-            )
-            return None
-        else:
-            return subclass_parsers
-
     def get_parser(
         self, parser_class: type[aap.AbstractAttributeParser], error_on_not_found=True
     ) -> aap.AbstractAttributeParser:

--- a/opencsp/common/lib/render/ImageAttributeParser.py
+++ b/opencsp/common/lib/render/ImageAttributeParser.py
@@ -69,7 +69,7 @@ class ImageAttributeParser(aap.AbstractAttributeParser):
             attributes_file = os.path.join(opath, f"{oname}.txt")
             self._previous_attr = am.AttributesManager()
             self._previous_attr.load(attributes_file)
-        except:
+        except Exception as e:
             pass
         if self._previous_attr != None:
             prev_image_attr: ImageAttributeParser = self._previous_attr.get_parser(self.__class__)

--- a/opencsp/common/lib/render/test/test_ImageAttributeParser.py
+++ b/opencsp/common/lib/render/test/test_ImageAttributeParser.py
@@ -49,7 +49,6 @@ class test_ImageAttributeParser(unittest.TestCase):
         parser = iap.ImageAttributeParser(notes="")
         self.assertEqual(True, parser.has_contents())
 
-    @pytest.mark.skip("See https://github.com/sandialabs/OpenCSP/issues/3")
     def test_with_attrfile(self):
         """Load all values from the associated attributes file. Use the new current_image_source value."""
         parser = iap.ImageAttributeParser(current_image_source=self.img_file)

--- a/opencsp/common/lib/tool/file_tools.py
+++ b/opencsp/common/lib/tool/file_tools.py
@@ -35,9 +35,11 @@ def path_components(input_dir_body_ext: str):
 
     See also: body_ext_given_file_dir_body_ext()
     """
+
     dir = os.path.dirname(input_dir_body_ext)
     body_ext = os.path.basename(input_dir_body_ext)
     body, ext = os.path.splitext(body_ext)
+
     return dir, body, ext
 
 


### PR DESCRIPTION
## Purpose

Fixes #3

## Summary of changes

Broke subclass parser search in get_parser out into separate function that returns a list of all subclass parsers found

## Implementation notes

An unordered set the type of the global variable `_registered_parser_classes`. What causes the bug is the unordered nature of processing this set. Each implementation of the abstract `AttributeParser` registers itself when opencsp fires up. When `SpotAnalysisAttributeParser` is encoutered first during `AttributeManager`/`get_parser`, the unordered structure of `_registered_parser_classes` can result in the fall-through path to search and returning a subclass parser. This in-turn results in some members of the parser, `date_collected` in this instance, not getting initialized. Removing the fall back path of searching for subclass parsers in `get_parser` fixes this spurious failure.

## Submission checklist
- [x] Target branch is `develop`, not `main`
- [ ] Existing tests are updated or new tests were added
- [x] `opencsp/test/test_DocStringsExist.py` are verified to include this change or have been updated accordingly
- [x] .rst file(s) under `doc/` are verified to include this change or have been updated accordingly

## Additional information

It's not clear to me what the original intended functionality of `get_parser` was. Reviewers should check the doc strings and any potential breakage via removal of subclass parser searching.