### PR TITLE
Restrict scipy version, <= 1.14.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pandas >= 2.2.1
 pillow >= 10.2.0
 pyproj >= 3.6.1
 pytz >= 2024.1
-scipy >= 1.12.0
+scipy >= 1.12.0, <= 1.14.1
 sympy >= 1.12
 
 # packages that can't be installed with conda but can be installed with pip on solo #pippkgs


### PR DESCRIPTION
## Purpose

Address spurious failures reported in #198.

## Summary of changes

Restrict scipy version to <= 1.14.1

## Implementation notes

_Please describe any relevant implementation details for reviewers, e.g. how correctness was verified._

## Submission checklist
- [x] Target branch is `develop`, not `main`
- [x] Existing tests are updated or new tests were added
- [x] `opencsp/test/test_DocStringsExist.py` are verified to include this change or have been updated accordingly
- [x] .rst file(s) under `doc/` are verified to include this change or have been updated accordingly

## Additional information

Closes #198.