### PR TITLE
Prepare dockerfiles to support multiple architectures and launching GUIs (arm64 in addition to amd64)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build image
-        run: echo UBI8_IMAGE=$UBI8_IMAGE && docker build . --file Dockerfile --tag $UBI8_IMAGE --label "runnumber=${GITHUB_RUN_ID}"
+        run: |
+          echo UBI8_IMAGE=$UBI8_IMAGE
+          cp requirements.txt ./docker
+          docker build ./docker --file Dockerfile --tag $UBI8_IMAGE --label "runnumber=${GITHUB_RUN_ID}"
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,36 +1,69 @@
 name: github-DOCKER
 
 on:
-  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+    - '**/*.rst'
+    - '**/*.md'
+    - 'doc/**'
+    types: [ opened, reopened, synchronize ]  
   push:
     branches:
-      - main      
+      - main
 
 permissions:
   contents: none
 
 env:
-  UBI8_IMAGE: "ghcr.io/sandialabs/opencsp:latest-ubi8"
+  IMAGE_REGISTRY: "ghcr.io/sandialabs/opencsp"
 
 jobs:
-  ubi8-image:
+  container_build_matrix:
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
+    strategy:
+      matrix:
+        dockerfile: [Dockerfile, Dockerfile_x11]
+        include:
+        - dockerfile: Dockerfile
+          ARCH: amd64
+          TAG: ubi8
+
+        - dockerfile: Dockerfile_x11
+          ARCH: amd64
+          TAG: ubi8-x11
+          
+        - dockerfile: Dockerfile_x11
+          ARCH: arm64
+          TAG: ubi8-x11
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set vars
+        run: |
+          export REV=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            export REV=latest
+          fi
+          
+          echo "FULL_TAG=$IMAGE_REGISTRY:${{matrix.TAG }}-${{matrix.ARCH}}-$REV" >> $GITHUB_ENV
+
       - name: Build image
         run: |
-          echo UBI8_IMAGE=$UBI8_IMAGE
           cp requirements.txt ./docker
-          docker build ./docker --file Dockerfile --tag $UBI8_IMAGE --label "runnumber=${GITHUB_RUN_ID}"
+          echo "FULL_TAG=$FULL_TAG"
+          docker build ./docker \
+            --build-arg="TARGET_ARCH=${{matrix.ARCH}}"
+            --file "${{matrix.dockerfile}}" \
+            --tag "$FULL_TAG" \
+            --label "runnumber=${GITHUB_RUN_ID}"
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Push image
         run: |
-          echo UBI8_IMAGE=$UBI8_IMAGE
-          docker push $UBI8_IMAGE
+          echo "FULL_TAG=$FULL_TAG"
+          docker push "$FULL_TAG"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,9 +20,6 @@ env:
 jobs:
   container_build_matrix:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     strategy:
       matrix:
         dockerfile: [Dockerfile, Dockerfile_x11]
@@ -67,3 +64,7 @@ jobs:
         run: |
           echo "FULL_TAG=$FULL_TAG"
           docker push "$FULL_TAG"
+
+    permissions:
+      packages: write
+      contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,7 +55,7 @@ jobs:
           cp requirements.txt ./docker
           echo "FULL_TAG=$FULL_TAG"
           docker build ./docker \
-            --build-arg="TARGET_ARCH=${{matrix.ARCH}}"
+            --build-arg="TARGET_ARCH=${{matrix.ARCH}}" \
             --file "${{matrix.dockerfile}}" \
             --tag "$FULL_TAG" \
             --label "runnumber=${GITHUB_RUN_ID}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,15 +1,10 @@
 name: github-DOCKER
 
 on:
-  pull_request:
-    paths-ignore:
-    - '**/*.rst'
-    - '**/*.md'
-    - 'doc/**'
-    types: [ opened, reopened, synchronize ]  
   push:
     branches:
       - main
+      - develop
 
 permissions:
   contents: none

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ARG BASE_IMAGE_ARG=registry.access.redhat.com/ubi8:latest
 FROM ${BASE_IMAGE_ARG}
 
-COPY docker/xvfb-rpms /tmp
+COPY xvfb-rpms /tmp
 
-RUN yum -y install python3.11 \
+RUN yum -y --nobest install python3.11 \
     python3.11-devel \
     python3.11-pip \
     mesa-libGL \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE_ARG}
 
 COPY xvfb-rpms /tmp
 
-RUN yum -y --nobest install python3.11 \
+RUN yum -y install python3.11 \
     python3.11-devel \
     python3.11-pip \
     mesa-libGL \

--- a/Dockerfile_x11
+++ b/Dockerfile_x11
@@ -1,0 +1,29 @@
+ARG BASE_IMAGE_ARG=registry.access.redhat.com/ubi8:latest
+FROM ${BASE_IMAGE_ARG}
+ARG TARGET_ARCH=amd64
+
+RUN yum -y install python3.11 \
+    python3.11-devel \
+    python3.11-pip \
+    mesa-libGL \
+    python3.11-tkinter \
+    xz \
+    gcc
+
+# Installing ffmpeg via relies on the rpmfusion repo and SDL2
+# The SDL2 yum package is not currently available in ubi8
+# Consequently, we download and install ffmpeg as a statically
+# linked binary below.
+WORKDIR /code
+ADD https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-$TARGET_ARCH-static.tar.xz /code
+RUN tar -xf ffmpeg-*-$TARGET_ARCH-static.tar.xz && \
+    cp /code/ffmpeg-*-$TARGET_ARCH-static/ffmpeg /usr/local/bin && \
+    cp /code/ffmpeg-*-$TARGET_ARCH-static/ffprobe /usr/local/bin
+
+ENV PYTHONPATH=/code
+
+COPY requirements.txt /code/
+RUN python3 -m pip install -r requirements.txt && \
+    python3 -m pip install pip-licenses && \
+    pip-licenses
+ENV PATH=$HOME/.local/bin:$PATH

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -166,6 +166,37 @@ How to install OpenCSP's dependencies
 
 With python version 3.10 or greater, run the following:
 
+Docker (Headless)
+^^^^^^^^^^^^^^^^^
+
+::
+    $ cd /path/to/OpenCSP/
+    $ export ARCH=arm64 # set this to amd64 for amd64 hardware
+    $ docker build -build-arg="TARGET_ARG=$ARCH" --arch $ARCH -t opencsp-dev-ubi8-$ARCH -f Dockerfile ./docker
+
+Docker (Xorg)
+^^^^^^^^^^^^^
+
+For MacOS, install xquartz. Open the xquartz xterm and run `xhost +localhost`. Open the xquartz preferences, and, in the security tab, select "Allow connections from network clients".
+
+For Windows, install vcxsrv. Open vcxsrv and select 'Multiple Windows', set display number to 0, enable start no client, disable access control. Click finish to start the server.
+
+::
+    $ cd /path/to/OpenCSP/
+    $ export ARCH=arm64 # set this to amd64 for amd64 hardware
+    $ docker build --build-arg="TARGET_ARG=$ARCH" --arch $ARCH -t opencsp-dev-ubi8-x11-$ARCH -f Dockerfile_x11 ./docker
+    # For podman desktop:
+    $ podman run -it --rm --env DISPLAY=host.docker.internal:0 --volume /tmp/.X11-unix:/tmp/.X11-unix -v$PWD:/code opencsp-dev-ubi8-x11-$ARCH "/bin/bash"
+    # Otherwise:
+    $ docker run -it --rm --env DISPLAY=$DISPLAY --volume /tmp/.X11-unix:/tmp/.X11-unix -v$PWD:/code opencsp-dev-ubi8-x11-$ARCH "/bin/bash"
+
+To expose a device such as a camera in docker, use:
+
+::
+    docker run --device /path/to/device ...
+
+On linux, the device is typically in /dev/.
+
 Linux
 ^^^^^
 


### PR DESCRIPTION
## Purpose

Prepare dockerfiles to support multiple architectures and launching GUIs (arm64 in addition to amd64)

## Summary of changes

Improved performance of docker build (build context is minimal via ./docker now)
Added Dockerfile_x11
Reworked docker.yml to build both archs for x11.
Updated contributors guide with initial instructions for how to build and run opencsp in the containers.

## Implementation notes

Correctness was verified by building and running the x11 image locally. As well as running the opencsp test suite. Causes #

## Submission checklist
- [x] Target branch is `develop`, not `main`
- [x] Existing tests are updated or new tests were added
- [x] `opencsp/test/test_DocStringsExist.py` are verified to include this change or have been updated accordingly
- [x] .rst file(s) under `doc/` are verified to include this change or have been updated accordingly

## Additional information

Related to / causes: https://github.com/sandialabs/OpenCSP/issues/206