### PR TITLE
fix matplotlib support on Mac

### DIFF
--- a/opencsp/__init__.py
+++ b/opencsp/__init__.py
@@ -18,6 +18,15 @@ import os
 import copy
 import sys
 import argparse
+import platform
+
+
+if platform.system() == 'Darwin':
+    # On Mac, force matplotlib to use the TkAgg.
+    # Maybe we consider doing this for all systems?
+    import matplotlib
+
+    matplotlib.use('TkAgg')
 
 
 def _opencsp_settings_dirs() -> list[str]:


### PR DESCRIPTION
## Purpose

fix matplotlib on mac

## Summary of changes

Force matplotlib to use a known good backend.

## Implementation notes

I don't remember what made me choose this backend. Sorry!

## Submission checklist
- [x] Target branch is `develop`, not `main`
- [ ] Existing tests are updated or new tests were added
- [ ] ~`opencsp/test/test_DocStringsExist.py` are verified to include this change or have been updated accordingly~
- [ ] .rst file(s) under `doc/` are verified to include this change or have been updated accordingly

## Additional information

We should consider if we want to enforce this change on all systems, not just for Macs.