### PR TITLE
Formatted with black

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,10 +3,10 @@ name: github-FORMAT
 on:
   pull_request:
     paths-ignore:
-    - '**/*.rst'
-    - '**/*.md'
-    - 'doc/**'
-    types: [ opened, reopened, synchronize ]
+      - "**/*.rst"
+      - "**/*.md"
+      - "doc/**"
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: none
@@ -28,9 +28,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Black formatting check
         run: |
-          pip install black
+          pip install black==24.10.0
           cd OpenCSP
           black . -S -C --check --diff --config ./pyproject.toml


### PR DESCRIPTION
## Purpose

Black appears to have been updated to now check module docstrings. This PR brings OpenCSP up to date with black.

## Summary of changes

Ran black formatter

## Implementation notes

None, just ran black

## Submission checklist
- [x] Target branch is `develop`, not `main`
- [x] Existing tests are updated or new tests were added
- [x] `opencsp/test/test_DocStringsExist.py` are verified to include this change or have been updated accordingly
- [x] .rst file(s) under `doc/` are verified to include this change or have been updated accordingly

## Additional information

None