### PR TITLE
Aruco Marker Generation Update

### DIFF
--- a/example/scene_reconstruction/example_make_aruco_markers.py
+++ b/example/scene_reconstruction/example_make_aruco_markers.py
@@ -12,55 +12,63 @@ import numpy as np
 import opencsp.common.lib.tool.file_tools as ft
 
 
-def make_aruco_images(save_path: str, number: str, size: int = 500, padding: int = 50):
-    """Generates aruco marker images and saves images as PNG files
+def example_make_aruco_images():
+    """Example script that makes aruco markers images and saves as PNG files. The
+    Aruco marker images are square images with a white border. The Aruco marker ID
+    is printed on the bottom left corner of the image. These PNG images can be
+    printed to make physical aruco markers.
 
-    Parameters
-    ----------
-    save_path : str
-        Path to save marker images
-    number : str
-        Number of markers to make, starting at ID=0
-    size : int, optional
-        Size of active area, pixels, by default 500
-    padding : int, optional
-        Size of white border, pixels, by default 50
+    This example, when run as-is, will save 10 Aruco marker images with an active aruco
+    marker size of 500x500 pixels with 150 pixels of white padding around the edge for a
+    final size of 800x800 pixels. The images are saved in:
+    /example/scene_reconstruction/data/output/aruco_markers/.
+
+    The following variables can be updated to make markers with different properties:
+    - number : the number of Aruco markers to make
+    - marker_active_size : the width/height (in pixels) of the entire Aruco marker active
+        area (not including the white padding around the edge)
+    - padding : the width of the padding (in pixels) around the perimeter of the active
+        marker area. NOTE: if the padding is too small, the text label will not be visible.
+    - font_thickness : the thickness of the Aruco ID label font on the lower left corner
+    - save_path : the save path for generated Aruco marker PNG files
     """
+    ### UPDATE THESE PARAMETERS TO MAKE NEW MARKERS ###
+    number = 10
+    marker_active_size = 500
+    padding = 150
+    font_thickness = 2
+    save_path = join(dirname(__file__), 'data/output/aruco_markers')
+    ###################################################
+
+    ft.create_directories_if_necessary(save_path)
+
     # Define marker parameters
     dictionary = aruco.getPredefinedDictionary(aruco.DICT_4X4_1000)
-    side_pixels = size  # Side width
-    font_thickness = 2
-    pad_width = padding
 
     for id_ in range(number):
         # Define marker image
-        img = np.ones((side_pixels, side_pixels), dtype='uint8') * 255
+        img = np.ones((marker_active_size, marker_active_size), dtype='uint8') * 255
 
         # Create marker image
-        aruco.drawMarker(dictionary, id_, side_pixels, img[-side_pixels:, :])
+        aruco.generateImageMarker(dictionary, id_, marker_active_size, img[-marker_active_size:, :])
 
         # Add padding
-        img = np.pad(img, ((pad_width, pad_width), (pad_width, pad_width)), constant_values=255)
+        img = np.pad(img, ((padding, padding), (padding, padding)), constant_values=255)
 
         # Add text
         id_string = f'ID: {id_:d}'
-        cv.putText(img, id_string, (20, side_pixels + 2 * pad_width - 4), 0, 1, 0, font_thickness)
+        cv.putText(
+            img,
+            id_string,
+            (20, marker_active_size + 2 * padding - 20),
+            fontFace=0,
+            fontScale=1.5,
+            color=0,
+            thickness=font_thickness,
+        )
 
         # Save image
         imageio.imwrite(join(f'{save_path:s}', f'{id_:03d}.png'), img)
-
-
-def example_make_aruco_images():
-    """Example script that makes aruco markers images and saves as PNG files.
-    These can be printed to make physical aruco markers.
-    """
-    # Create save path
-    path = join(dirname(__file__), 'data/output/aruco_markers')
-    ft.create_directories_if_necessary(path)
-    # Define number of markers
-    num_markers = 10
-
-    make_aruco_images(path, num_markers)
 
 
 if __name__ == '__main__':

--- a/opencsp/common/lib/deflectometry/ImageProjection.py
+++ b/opencsp/common/lib/deflectometry/ImageProjection.py
@@ -629,5 +629,5 @@ class ImageProjection(hdf5_tools.HDF5_IO_Abstract):
         img_2d = np.ones((width, width), dtype='uint8') * self.display_data.projector_max_int
 
         # Create marker image
-        aruco.drawMarker(self.aruco_dictionary, id_, width, img_2d)
+        aruco.generateImageMarker(self.aruco_dictionary, id_, width, img_2d)
         return np.concatenate([img_2d[:, :, None]] * 3, axis=2)

--- a/opencsp/common/lib/deflectometry/test/test_ImageProjection.py
+++ b/opencsp/common/lib/deflectometry/test/test_ImageProjection.py
@@ -49,6 +49,22 @@ class test_ImageProjection(unittest.TestCase):
         image_projection.close()
         self.assertIsNone(ip.ImageProjection.instance())
 
+    def test_marker_images(self):
+        """Tests showing the cal marker images"""
+        # Load from HDF
+        image_projection = ip.ImageProjection.in_new_window(self.image_projection_data)
+        image_projection.show_calibration_marker_image()
+        image_projection.root.after(500, image_projection.close)
+        image_projection.run()
+
+    def test_fiducial_images(self):
+        """Tests showing the fiducial image"""
+        # Load from HDF
+        image_projection = ip.ImageProjection.in_new_window(self.image_projection_data)
+        image_projection.show_calibration_fiducial_image()
+        image_projection.root.after(500, image_projection.close)
+        image_projection.run()
+
     def test_on_close(self):
         """Tests closing callback"""
         global close_count


### PR DESCRIPTION
## Purpose

In the most up-to-date version of OpenCV, the aruco marker generation function call changed. This was causing errors in Sofast because the Aruco generation wasn't tested. 

## Summary of changes

- The ImageProjection class was updated to generate aruco markers correctly with the up-to-date OpenCV instance.
- The aruco marker generation example script was updated accordingly.
- Unit tests added to protect against this again in future. 

## Implementation notes

Added unit tests to ImageProjection to capture fiducials and calibration Aruco markers.

## Submission checklist
- [x] Target branch is `develop`, not `main`
- [x] Existing tests are updated or new tests were added
- [x] `opencsp/test/test_DocStringsExist.py` are verified to include this change or have been updated accordingly
- [x] .rst file(s) under `doc/` are verified to include this change or have been updated accordingly

## Additional information

**Note**: #236 (black formatting fix) needs to be updated and this rebased before merging.