### PR TITLE
Added a link to box example data

### DIFF
--- a/doc/source/example/index.rst
+++ b/doc/source/example/index.rst
@@ -15,3 +15,7 @@ This section describes the OpenCSP examples.
    sofast_fringe/index.rst
    solarfield/index.rst
    targetcolor/index.rst
+
+Note: To fetch sample data for all examples, click here_.
+
+.. _here: https://sandia-csp.app.box.com/s/iftmhdkhgjnmfgefsfmkid011dtv8n3g/folder/253231533209


### PR DESCRIPTION
## Purpose

The purpose of this pull request is to add a link to all example data that is located on the appropriate box page. Added this in successfully.

## Summary of changes

I added 2 lines of code to OpenCSP/doc/source/example/index.rst. In those 2 lines I add a statement for users to see and then provide a link that the user can then click on if they want to access any of the available data from box.

## Implementation notes

I modified the rst file and than ran the make_docs.sh script. I also don't think there are any tests involved with this? I will check with Evan.

## Submission checklist
- [x] Target branch is `develop`, not `main`
- [x] Existing tests are updated or new tests were added
- [ ] `opencsp/test/test_DocStringsExist.py` are verified to include this change or have been updated accordingly
- [ ] .rst file(s) under `doc/` are verified to include this change or have been updated accordingly

## Additional information

_Please provide any additional information here._